### PR TITLE
refactor for modern, typed, browser-compatible js

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x, 18.x, latest]
+        node-version: [12.x, 14.x, 16.x, 18.x, latest]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x, 18.x, latest]
+        node-version: [18.x, latest]
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -41,13 +41,15 @@ var HDKey = (globalThis.require && exports) || {};
 (function (window, HDKey) {
   "use strict";
 
+  let Crypto = window.crypto || require("node:crypto");
+
   let Buffer = require("safe-buffer").Buffer;
-  let crypto = require("crypto");
   let bs58check = require("bs58check");
   let RIPEMD160 = require("ripemd160");
   let secp256k1 = require("secp256k1");
 
-  let MASTER_SECRET = Buffer.from("Bitcoin seed", "utf8");
+  let textEncoder = new TextEncoder();
+  let MASTER_SECRET = textEncoder.encode("Bitcoin seed");
   let HARDENED_OFFSET = 0x80000000;
   let LEN = 78;
 
@@ -75,16 +77,16 @@ var HDKey = (globalThis.require && exports) || {};
     hdkey.getPrivateKey = function () {
       return _privateKey;
     };
-    hdkey.setPrivateKey = function (value) {
+    hdkey.setPrivateKey = async function (value) {
       assert(value.length === 32, "Private key must be 32 bytes.");
       assert(secp256k1.privateKeyVerify(value) === true, "Invalid private key");
 
       _privateKey = value;
       hdkey.publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
-      hdkey.identifier = hash160(hdkey.publicKey);
+      hdkey.identifier = await hash160(hdkey.publicKey);
     };
 
-    hdkey.setPublicKey = function (value) {
+    hdkey.setPublicKey = async function (value) {
       assert(
         value.length === 33 || value.length === 65,
         "Public key must be 33 or 65 bytes.",
@@ -93,12 +95,15 @@ var HDKey = (globalThis.require && exports) || {};
       // force compressed point (performs public key verification)
       let publicKey =
         value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
-      hdkey._setPublicKey(publicKey);
+      await hdkey._setPublicKey(publicKey);
     };
 
-    hdkey._setPublicKey = function (publicKey) {
+    /**
+     * @param {Uint8Array} publicKey
+     */
+    hdkey._setPublicKey = async function (publicKey) {
       hdkey.publicKey = Buffer.from(publicKey);
-      hdkey.identifier = hash160(publicKey);
+      hdkey.identifier = await hash160(publicKey);
       _privateKey = null;
     };
 
@@ -128,9 +133,10 @@ var HDKey = (globalThis.require && exports) || {};
       }
 
       // m, 44', 5', 0, 0, 0
-      let entries = path.split("/");
+      var entries = path.split("/");
       let _hdkey = hdkey;
-      entries.forEach(function (c, i) {
+      for (let i = 0; i < entries.length; i += 1) {
+        let c = entries[i];
         if (i === 0) {
           assert(/^[mM]{1}/.test(c), 'Path must start with "m" or "M"');
           return;
@@ -144,12 +150,12 @@ var HDKey = (globalThis.require && exports) || {};
         }
 
         _hdkey = _hdkey.deriveChild(childIndex);
-      });
+      }
 
       return _hdkey;
     };
 
-    hdkey.deriveChild = function (index) {
+    hdkey.deriveChild = async function (index) {
       let isHardened = index >= HARDENED_OFFSET;
       let indexBuffer = Buffer.allocUnsafe(4);
       indexBuffer.writeUInt32BE(index, 0);
@@ -173,10 +179,7 @@ var HDKey = (globalThis.require && exports) || {};
         data = Buffer.concat([hdkey.publicKey, indexBuffer]);
       }
 
-      let I = crypto
-        .createHmac("sha512", hdkey.chainCode)
-        .update(data)
-        .digest();
+      let I = await createHmac("SHA-512", hdkey.chainCode, data);
       let IL = I.slice(0, 32);
       let IR = I.slice(32);
 
@@ -186,7 +189,7 @@ var HDKey = (globalThis.require && exports) || {};
       if (_privateKey) {
         // ki = parse256(IL) + kpar (mod n)
         try {
-          hd.setPrivateKey(
+          await hd.setPrivateKey(
             Buffer.from(
               secp256k1.privateKeyTweakAdd(Buffer.from(_privateKey), IL),
             ),
@@ -194,7 +197,7 @@ var HDKey = (globalThis.require && exports) || {};
           // throw if IL >= n || (privateKey + IL) === 0
         } catch (err) {
           // In case parse256(IL) >= n or ki == 0, one should proceed with the next value for i
-          return hdkey.deriveChild(index + 1);
+          return await hdkey.deriveChild(index + 1);
         }
         // Public parent key -> public child key
       } else {
@@ -213,7 +216,7 @@ var HDKey = (globalThis.require && exports) || {};
           // throw if IL >= n || (g**IL + publicKey) is infinity
         } catch (err) {
           // In case parse256(IL) >= n or Ki is the point at infinity, one should proceed with the next value for i
-          return hdkey.deriveChild(index + 1);
+          return await hdkey.deriveChild(index + 1);
         }
       }
 
@@ -242,7 +245,7 @@ var HDKey = (globalThis.require && exports) || {};
 
     hdkey.wipePrivateData = function () {
       if (_privateKey) {
-        crypto.randomBytes(_privateKey.length).copy(_privateKey);
+        Crypto.getRandomValues(_privateKey.length).copy(_privateKey);
       }
       _privateKey = null;
       return hdkey;
@@ -258,22 +261,23 @@ var HDKey = (globalThis.require && exports) || {};
     return hdkey;
   };
 
-  HDKey.fromMasterSeed = function (seedBuffer, versions) {
-    let I = crypto
-      .createHmac("sha512", MASTER_SECRET)
-      .update(seedBuffer)
-      .digest();
+  HDKey.fromMasterSeed = async function (seedBuffer, versions) {
+    let I = await createHmac("SHA-512", MASTER_SECRET, seedBuffer);
     let IL = I.slice(0, 32);
     let IR = I.slice(32);
 
     let hdkey = HDKey.create(versions);
     hdkey.chainCode = IR;
-    hdkey.setPrivateKey(IL);
+    await hdkey.setPrivateKey(IL);
 
     return hdkey;
   };
 
-  HDKey.fromExtendedKey = function (base58key, versions, skipVerification) {
+  HDKey.fromExtendedKey = async function (
+    base58key,
+    versions,
+    skipVerification,
+  ) {
     // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
     versions = versions || BITCOIN_VERSIONS;
     skipVerification = skipVerification || false;
@@ -299,14 +303,14 @@ var HDKey = (globalThis.require && exports) || {};
         version === versions.private,
         "Version mismatch: version does not match private",
       );
-      hdkey.setPrivateKey(key.slice(1)); // cut off first 0x0 byte
+      await hdkey.setPrivateKey(key.slice(1)); // cut off first 0x0 byte
     } else {
       assert(
         version === versions.public,
         "Version mismatch: version does not match public",
       );
       if (skipVerification) {
-        hdkey._setPublicKey(key);
+        await hdkey._setPublicKey(key);
       } else {
         hdkey.setPublicKey(key);
       }
@@ -354,9 +358,38 @@ var HDKey = (globalThis.require && exports) || {};
   /**
    * @param {Uint8Array} buf
    */
-  function hash160(buf) {
-    let sha = crypto.createHash("sha256").update(buf).digest();
-    return new RIPEMD160().update(sha).digest();
+  async function hash160(buf) {
+    let sha = await Crypto.subtle.digest("SHA-256", buf);
+    let shaU8 = new Uint8Array(sha);
+    return new RIPEMD160().update(shaU8).digest();
+  }
+
+  /**
+   * @param {"SHA-256"|"SHA-512"} digest - "SHA-512" for us
+   * @param {Uint8Array} entropy - the hmac "secret key data" (public in this case)
+   * @param {Uint8Array} data - the hmac "message"
+   * @returns {Promise<Uint8Array>}
+   */
+  async function createHmac(digest, entropy, data) {
+    /** @type {"raw"|"pkcs8"|"spki"} */
+    let format = "raw";
+    let algo = {
+      name: "HMAC",
+      digest: "SHA-512",
+    };
+    let extractable = true;
+    /** @type {Array<KeyUsage>} */
+    let keyUsages = ["sign"];
+    let hmacKey = await Crypto.subtle.importKey(
+      format,
+      entropy,
+      algo,
+      extractable,
+      keyUsages,
+    );
+    let sig = await Crypto.subtle.sign("HMAC", hmacKey, data);
+    let u8 = new Uint8Array(sig);
+    return u8;
   }
 
   HDKey.HARDENED_OFFSET = HARDENED_OFFSET;

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -26,6 +26,9 @@ var HDKey = (globalThis.require && exports) || {};
     hdkey.index = 0;
     hdkey.privateKey = null;
     hdkey.publicKey = null;
+    // note: BIP-32 "Key Identifier" is the same as "Pub Key Hash"
+    // but used for a different purpose, hence the semantic name
+    hdkey.identifier = null;
     hdkey.chainCode = null;
     hdkey._fingerprint = 0;
     hdkey.parentFingerprint = 0;
@@ -35,16 +38,6 @@ var HDKey = (globalThis.require && exports) || {};
         return hdkey._fingerprint;
       },
     });
-    Object.defineProperty(hdkey, "identifier", {
-      get: function () {
-        return hdkey._identifier;
-      },
-    });
-    Object.defineProperty(hdkey, "pubKeyHash", {
-      get: function () {
-        return hdkey.identifier;
-      },
-    });
 
     hdkey.setPrivateKey = function (value) {
       assert.equal(value.length, 32, "Private key must be 32 bytes.");
@@ -52,8 +45,8 @@ var HDKey = (globalThis.require && exports) || {};
 
       hdkey.privateKey = value;
       hdkey.publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
-      hdkey._identifier = hash160(hdkey.publicKey);
-      hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
+      hdkey.identifier = hash160(hdkey.publicKey);
+      hdkey._fingerprint = hdkey.pubKeyHash.slice(0, 4).readUInt32BE(0);
     };
 
     hdkey.setPublicKey = function (value) {
@@ -304,8 +297,8 @@ var HDKey = (globalThis.require && exports) || {};
 
   function setPublicKey(hdkey, publicKey) {
     hdkey.publicKey = Buffer.from(publicKey);
-    hdkey._identifier = hash160(publicKey);
-    hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
+    hdkey.identifier = hash160(publicKey);
+    hdkey._fingerprint = hdkey.pubKeyHash.slice(0, 4).readUInt32BE(0);
     hdkey.privateKey = null;
   }
 

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -19,208 +19,211 @@ var HDKEY = (globalThis.require && exports) || {};
   var BITCOIN_VERSIONS = { private: 0x0488ade4, public: 0x0488b21e };
 
   HDKEY.create = function (versions) {
-    return new HDKey(versions);
-  };
-
-  function HDKey(versions) {
-    this.versions = versions || BITCOIN_VERSIONS;
-    this.depth = 0;
-    this.index = 0;
-    this._privateKey = null;
-    this._publicKey = null;
-    this.chainCode = null;
-    this._fingerprint = 0;
-    this.parentFingerprint = 0;
-  }
-
-  Object.defineProperty(HDKey.prototype, "fingerprint", {
-    get: function () {
-      return this._fingerprint;
-    },
-  });
-  Object.defineProperty(HDKey.prototype, "identifier", {
-    get: function () {
-      return this._identifier;
-    },
-  });
-  Object.defineProperty(HDKey.prototype, "pubKeyHash", {
-    get: function () {
-      return this.identifier;
-    },
-  });
-
-  Object.defineProperty(HDKey.prototype, "privateKey", {
-    get: function () {
-      return this._privateKey;
-    },
-    set: function (value) {
-      assert.equal(value.length, 32, "Private key must be 32 bytes.");
-      assert(secp256k1.privateKeyVerify(value) === true, "Invalid private key");
-
-      this._privateKey = value;
-      this._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
-      this._identifier = hash160(this.publicKey);
-      this._fingerprint = this._identifier.slice(0, 4).readUInt32BE(0);
-    },
-  });
-
-  Object.defineProperty(HDKey.prototype, "publicKey", {
-    get: function () {
-      return this._publicKey;
-    },
-    set: function (value) {
-      assert(
-        value.length === 33 || value.length === 65,
-        "Public key must be 33 or 65 bytes.",
-      );
-      assert(secp256k1.publicKeyVerify(value) === true, "Invalid public key");
-      // force compressed point (performs public key verification)
-      const publicKey =
-        value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
-      setPublicKey(this, publicKey);
-    },
-  });
-
-  Object.defineProperty(HDKey.prototype, "privateExtendedKey", {
-    get: function () {
-      if (this._privateKey)
-        return bs58check.encode(
-          serialize(
-            this,
-            this.versions.private,
-            Buffer.concat([Buffer.alloc(1, 0), this.privateKey]),
-          ),
-        );
-      else return null;
-    },
-  });
-
-  Object.defineProperty(HDKey.prototype, "publicExtendedKey", {
-    get: function () {
-      return bs58check.encode(
-        serialize(this, this.versions.public, this.publicKey),
-      );
-    },
-  });
-
-  HDKey.prototype.derive = function (path) {
-    if (path === "m" || path === "M" || path === "m'" || path === "M'") {
-      return this;
+    function HDKey(versions) {
+      this.versions = versions || BITCOIN_VERSIONS;
+      this.depth = 0;
+      this.index = 0;
+      this._privateKey = null;
+      this._publicKey = null;
+      this.chainCode = null;
+      this._fingerprint = 0;
+      this.parentFingerprint = 0;
     }
 
-    var entries = path.split("/");
-    var hdkey = this;
-    entries.forEach(function (c, i) {
-      if (i === 0) {
-        assert(/^[mM]{1}/.test(c), 'Path must start with "m" or "M"');
-        return;
-      }
-
-      var hardened = c.length > 1 && c[c.length - 1] === "'";
-      var childIndex = parseInt(c, 10); // & (HARDENED_OFFSET - 1)
-      assert(childIndex < HARDENED_OFFSET, "Invalid index");
-      if (hardened) childIndex += HARDENED_OFFSET;
-
-      hdkey = hdkey.deriveChild(childIndex);
+    Object.defineProperty(HDKey.prototype, "fingerprint", {
+      get: function () {
+        return this._fingerprint;
+      },
+    });
+    Object.defineProperty(HDKey.prototype, "identifier", {
+      get: function () {
+        return this._identifier;
+      },
+    });
+    Object.defineProperty(HDKey.prototype, "pubKeyHash", {
+      get: function () {
+        return this.identifier;
+      },
     });
 
-    return hdkey;
-  };
-
-  HDKey.prototype.deriveChild = function (index) {
-    var isHardened = index >= HARDENED_OFFSET;
-    var indexBuffer = Buffer.allocUnsafe(4);
-    indexBuffer.writeUInt32BE(index, 0);
-
-    var data;
-
-    if (isHardened) {
-      // Hardened child
-      assert(this.privateKey, "Could not derive hardened child key");
-
-      var pk = this.privateKey;
-      var zb = Buffer.alloc(1, 0);
-      pk = Buffer.concat([zb, pk]);
-
-      // data = 0x00 || ser256(kpar) || ser32(index)
-      data = Buffer.concat([pk, indexBuffer]);
-    } else {
-      // Normal child
-      // data = serP(point(kpar)) || ser32(index)
-      //      = serP(Kpar) || ser32(index)
-      data = Buffer.concat([this.publicKey, indexBuffer]);
-    }
-
-    var I = crypto.createHmac("sha512", this.chainCode).update(data).digest();
-    var IL = I.slice(0, 32);
-    var IR = I.slice(32);
-
-    var hd = new HDKey(this.versions);
-
-    // Private parent key -> private child key
-    if (this.privateKey) {
-      // ki = parse256(IL) + kpar (mod n)
-      try {
-        hd.privateKey = Buffer.from(
-          secp256k1.privateKeyTweakAdd(Buffer.from(this.privateKey), IL),
+    Object.defineProperty(HDKey.prototype, "privateKey", {
+      get: function () {
+        return this._privateKey;
+      },
+      set: function (value) {
+        assert.equal(value.length, 32, "Private key must be 32 bytes.");
+        assert(
+          secp256k1.privateKeyVerify(value) === true,
+          "Invalid private key",
         );
-        // throw if IL >= n || (privateKey + IL) === 0
-      } catch (err) {
-        // In case parse256(IL) >= n or ki == 0, one should proceed with the next value for i
-        return this.deriveChild(index + 1);
-      }
-      // Public parent key -> public child key
-    } else {
-      // Ki = point(parse256(IL)) + Kpar
-      //    = G*IL + Kpar
-      try {
-        hd.publicKey = Buffer.from(
-          secp256k1.publicKeyTweakAdd(Buffer.from(this.publicKey), IL, true),
+
+        this._privateKey = value;
+        this._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
+        this._identifier = hash160(this.publicKey);
+        this._fingerprint = this._identifier.slice(0, 4).readUInt32BE(0);
+      },
+    });
+
+    Object.defineProperty(HDKey.prototype, "publicKey", {
+      get: function () {
+        return this._publicKey;
+      },
+      set: function (value) {
+        assert(
+          value.length === 33 || value.length === 65,
+          "Public key must be 33 or 65 bytes.",
         );
-        // throw if IL >= n || (g**IL + publicKey) is infinity
-      } catch (err) {
-        // In case parse256(IL) >= n or Ki is the point at infinity, one should proceed with the next value for i
-        return this.deriveChild(index + 1);
+        assert(secp256k1.publicKeyVerify(value) === true, "Invalid public key");
+        // force compressed point (performs public key verification)
+        const publicKey =
+          value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
+        setPublicKey(this, publicKey);
+      },
+    });
+
+    Object.defineProperty(HDKey.prototype, "privateExtendedKey", {
+      get: function () {
+        if (this._privateKey)
+          return bs58check.encode(
+            serialize(
+              this,
+              this.versions.private,
+              Buffer.concat([Buffer.alloc(1, 0), this.privateKey]),
+            ),
+          );
+        else return null;
+      },
+    });
+
+    Object.defineProperty(HDKey.prototype, "publicExtendedKey", {
+      get: function () {
+        return bs58check.encode(
+          serialize(this, this.versions.public, this.publicKey),
+        );
+      },
+    });
+
+    HDKey.prototype.derive = function (path) {
+      if (path === "m" || path === "M" || path === "m'" || path === "M'") {
+        return this;
       }
-    }
 
-    hd.chainCode = IR;
-    hd.depth = this.depth + 1;
-    hd.parentFingerprint = this.fingerprint; // .readUInt32BE(0)
-    hd.index = index;
+      var entries = path.split("/");
+      var hdkey = this;
+      entries.forEach(function (c, i) {
+        if (i === 0) {
+          assert(/^[mM]{1}/.test(c), 'Path must start with "m" or "M"');
+          return;
+        }
 
-    return hd;
-  };
+        var hardened = c.length > 1 && c[c.length - 1] === "'";
+        var childIndex = parseInt(c, 10); // & (HARDENED_OFFSET - 1)
+        assert(childIndex < HARDENED_OFFSET, "Invalid index");
+        if (hardened) childIndex += HARDENED_OFFSET;
 
-  HDKey.prototype.sign = function (hash) {
-    return Buffer.from(
-      secp256k1.ecdsaSign(
-        Uint8Array.from(hash),
-        Uint8Array.from(this.privateKey),
-      ).signature,
-    );
-  };
+        hdkey = hdkey.deriveChild(childIndex);
+      });
 
-  HDKey.prototype.verify = function (hash, signature) {
-    return secp256k1.ecdsaVerify(
-      Uint8Array.from(signature),
-      Uint8Array.from(hash),
-      Uint8Array.from(this.publicKey),
-    );
-  };
-
-  HDKey.prototype.wipePrivateData = function () {
-    if (this._privateKey)
-      crypto.randomBytes(this._privateKey.length).copy(this._privateKey);
-    this._privateKey = null;
-    return this;
-  };
-
-  HDKey.prototype.toJSON = function () {
-    return {
-      xpriv: this.privateExtendedKey,
-      xpub: this.publicExtendedKey,
+      return hdkey;
     };
+
+    HDKey.prototype.deriveChild = function (index) {
+      var isHardened = index >= HARDENED_OFFSET;
+      var indexBuffer = Buffer.allocUnsafe(4);
+      indexBuffer.writeUInt32BE(index, 0);
+
+      var data;
+
+      if (isHardened) {
+        // Hardened child
+        assert(this.privateKey, "Could not derive hardened child key");
+
+        var pk = this.privateKey;
+        var zb = Buffer.alloc(1, 0);
+        pk = Buffer.concat([zb, pk]);
+
+        // data = 0x00 || ser256(kpar) || ser32(index)
+        data = Buffer.concat([pk, indexBuffer]);
+      } else {
+        // Normal child
+        // data = serP(point(kpar)) || ser32(index)
+        //      = serP(Kpar) || ser32(index)
+        data = Buffer.concat([this.publicKey, indexBuffer]);
+      }
+
+      var I = crypto.createHmac("sha512", this.chainCode).update(data).digest();
+      var IL = I.slice(0, 32);
+      var IR = I.slice(32);
+
+      var hd = HDKEY.create(this.versions);
+
+      // Private parent key -> private child key
+      if (this.privateKey) {
+        // ki = parse256(IL) + kpar (mod n)
+        try {
+          hd.privateKey = Buffer.from(
+            secp256k1.privateKeyTweakAdd(Buffer.from(this.privateKey), IL),
+          );
+          // throw if IL >= n || (privateKey + IL) === 0
+        } catch (err) {
+          // In case parse256(IL) >= n or ki == 0, one should proceed with the next value for i
+          return this.deriveChild(index + 1);
+        }
+        // Public parent key -> public child key
+      } else {
+        // Ki = point(parse256(IL)) + Kpar
+        //    = G*IL + Kpar
+        try {
+          hd.publicKey = Buffer.from(
+            secp256k1.publicKeyTweakAdd(Buffer.from(this.publicKey), IL, true),
+          );
+          // throw if IL >= n || (g**IL + publicKey) is infinity
+        } catch (err) {
+          // In case parse256(IL) >= n or Ki is the point at infinity, one should proceed with the next value for i
+          return this.deriveChild(index + 1);
+        }
+      }
+
+      hd.chainCode = IR;
+      hd.depth = this.depth + 1;
+      hd.parentFingerprint = this.fingerprint; // .readUInt32BE(0)
+      hd.index = index;
+
+      return hd;
+    };
+
+    HDKey.prototype.sign = function (hash) {
+      return Buffer.from(
+        secp256k1.ecdsaSign(
+          Uint8Array.from(hash),
+          Uint8Array.from(this.privateKey),
+        ).signature,
+      );
+    };
+
+    HDKey.prototype.verify = function (hash, signature) {
+      return secp256k1.ecdsaVerify(
+        Uint8Array.from(signature),
+        Uint8Array.from(hash),
+        Uint8Array.from(this.publicKey),
+      );
+    };
+
+    HDKey.prototype.wipePrivateData = function () {
+      if (this._privateKey)
+        crypto.randomBytes(this._privateKey.length).copy(this._privateKey);
+      this._privateKey = null;
+      return this;
+    };
+
+    HDKey.prototype.toJSON = function () {
+      return {
+        xpriv: this.privateExtendedKey,
+        xpub: this.publicExtendedKey,
+      };
+    };
+
+    return new HDKey(versions);
   };
 
   HDKEY.fromMasterSeed = function (seedBuffer, versions) {
@@ -231,7 +234,7 @@ var HDKEY = (globalThis.require && exports) || {};
     var IL = I.slice(0, 32);
     var IR = I.slice(32);
 
-    var hdkey = new HDKey(versions);
+    var hdkey = HDKEY.create(versions);
     hdkey.chainCode = IR;
     hdkey.privateKey = IL;
 
@@ -242,7 +245,7 @@ var HDKEY = (globalThis.require && exports) || {};
     // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
     versions = versions || BITCOIN_VERSIONS;
     skipVerification = skipVerification || false;
-    var hdkey = new HDKey(versions);
+    var hdkey = HDKEY.create(versions);
 
     var keyBuffer = bs58check.decode(base58key);
 

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -1,3 +1,40 @@
+/**
+ * @typedef HDKey
+ * @prop {HDCreate} create
+ * @prop {HDFromSeed} fromMasterSeed
+ * @prop {HDFromXKey} fromExtendedKey
+ * @prop {HDFromJSON} fromJSON - TODO create()?
+ * @prop {Number} HARDENED_OFFSET - 0x80000000
+ */
+
+/**
+ * @callback HDCreate
+ * @param {HDVersions} versions
+ * @returns {hdkey}
+ */
+
+/**
+ * @typedef hdkey
+ * @prop {Uint8Array} chainCode - extra 32-bytes of shared entropy for xkeys
+ * @prop {Number} depth - of hd path - typically 0 is seed, 1-3 hardened, 4-5 are not
+ * @prop {Uint8Array} identifier - same bytes as pubKeyHash, but used for id
+ * @prop {Number} index - the final segment of an HD Path, the index of the wif/addr
+ * @prop {Number} parentFingerprint - 32-bit int, slice of id, stored in child xkeys
+ * @prop {Uint8Array} publicKey
+ * @prop {HDVersions} versions - magic bytes for base58 prefix
+ * @prop {HDDerivePath} derive - derive a full hd path from the given root
+ * @prop {HDDeriveChild} deriveChild - get the next child xkey (in a path segment)
+ * @prop {HDFingerprint} getFingerprint
+ * @prop {HDGetString} getPrivateExtendedKey
+ * @prop {HDGetBuffer} getPrivateKey
+ * @prop {HDGetString} getPublicExtendedKey
+ * @prop {HDSetBuffer} setPublicKey
+ * @prop {HDSetBuffer} setPrivateKey
+ * @prop {HDToJSON} toJSON
+ * @prop {HDWipePrivates} wipePrivateData - randomizes private key buffer in-place
+ * @prop {Function} _setPublicKey
+ */
+
 /** @type {HDKey} */
 //@ts-ignore
 var HDKey = (globalThis.require && exports) || {};
@@ -18,17 +55,16 @@ var HDKey = (globalThis.require && exports) || {};
   var BITCOIN_VERSIONS = { private: 0x0488ade4, public: 0x0488b21e };
 
   HDKey.create = function (versions) {
+    /** @type {hdkey} */
     var hdkey = {};
+    /** @type {Uint8Array?} */
     var _privateKey = null;
 
     hdkey.versions = versions || BITCOIN_VERSIONS;
     hdkey.depth = 0;
     hdkey.index = 0;
     hdkey.publicKey = null;
-    // note: BIP-32 "Key Identifier" is the same as "Pub Key Hash"
-    // but used for a different purpose, hence the semantic name
     hdkey.identifier = null;
-    // note: chainCode is public
     hdkey.chainCode = null;
     hdkey.parentFingerprint = 0;
 
@@ -91,6 +127,7 @@ var HDKey = (globalThis.require && exports) || {};
         return hdkey;
       }
 
+      // m, 44', 5', 0, 0, 0
       var entries = path.split("/");
       var _hdkey = hdkey;
       entries.forEach(function (c, i) {
@@ -282,12 +319,21 @@ var HDKey = (globalThis.require && exports) || {};
     return HDKey.fromExtendedKey(obj.xpriv);
   };
 
+  /**
+   * @param {Boolean} assertion
+   * @param {String} message
+   */
   function assert(assertion, message) {
     if (!assertion) {
       throw new Error(message);
     }
   }
 
+  /**
+   * @param {hdkey} hdkey - TODO attach to hdkey
+   * @param {Number} version
+   * @param {Uint8Array} key
+   */
   function serialize(hdkey, version, key) {
     // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
     var buffer = Buffer.allocUnsafe(LEN);
@@ -305,6 +351,9 @@ var HDKey = (globalThis.require && exports) || {};
     return buffer;
   }
 
+  /**
+   * @param {Uint8Array} buf
+   */
   function hash160(buf) {
     var sha = crypto.createHash("sha256").update(buf).digest();
     return new RIPEMD160().update(sha).digest();
@@ -315,3 +364,96 @@ var HDKey = (globalThis.require && exports) || {};
 if ("object" === typeof module) {
   module.exports = HDKey;
 }
+
+// Type Definitions
+
+/**
+ * @typedef HDVersions
+ * @prop {Number} private - 32-bit int (encodes to 'xprv' in base58)
+ * @prop {Number} public - 32-bit int (encodes to 'xpub' in base58)
+ */
+
+/**
+ * @typedef HDJSON
+ * @prop {String} xpriv - base58check-encoded extended private key (deprecated)
+ * @prop {String} xprv - base58check-encoded extended private key
+ * @prop {String} xpub - base58check-encoded extended public key
+ */
+
+// Function Definitions
+
+/**
+ * @callback HDDeriveChild
+ * @param {Number} index - includes HARDENED_OFFSET, if applicable
+ */
+
+/**
+ * @callback HDDerivePath
+ * @param {String} path
+ */
+
+/**
+ * @callback HDFingerprint
+ * @returns {Number}
+ */
+
+/**
+ * @callback HDFromXKey
+ * @param {String} base58key - base58check-encoded xkey
+ * @param {HDVersions} versions
+ * @param {Boolean} skipVerification
+ * returns {hdkey}
+ */
+
+/**
+ * @callback HDFromJSON
+ * @param {HDFromJSONOpts} opts
+ * returns {hdkey}
+ *
+ * @typedef HDFromJSONOpts
+ * @prop {String} [xpriv] - deprecated
+ * @prop {String} xprv
+ */
+
+/**
+ * @callback HDFromSeed
+ * @param {Uint8Array} seedBuffer
+ * @param {HDVersions} versions
+ */
+
+/**
+ * @callback HDGetBuffer
+ * @returns {Uint8Array}
+ */
+
+/**
+ * @callback HDGetString
+ * @param {String} str
+ */
+
+/**
+ * @callback HDSetBuffer
+ * @param {Uint8Array} u8
+ */
+
+/**
+ * @callback HDSign
+ * @param {Uint8Array} hash
+ * @returns {Uint8Array} - signature
+ */
+
+/**
+ * @callback HDToJSON
+ * @returns {HDJSON}
+ */
+
+/**
+ * @callback HDVerify
+ * @param {Uint8Array} hash
+ * @param {Uint8Array} signature
+ * @returns {Boolean}
+ */
+
+/**
+ * @callback HDWipePrivates
+ */

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -57,27 +57,23 @@ var HDKey = (globalThis.require && exports) || {};
       setPublicKey(hdkey, publicKey);
     };
 
-    Object.defineProperty(hdkey, "privateExtendedKey", {
-      get: function () {
-        if (hdkey.privateKey)
-          return bs58check.encode(
-            serialize(
-              hdkey,
-              hdkey.versions.private,
-              Buffer.concat([Buffer.alloc(1, 0), hdkey.privateKey]),
-            ),
-          );
-        else return null;
-      },
-    });
-
-    Object.defineProperty(hdkey, "publicExtendedKey", {
-      get: function () {
+    hdkey.getPrivateExtendedKey = function () {
+      if (hdkey.privateKey)
         return bs58check.encode(
-          serialize(hdkey, hdkey.versions.public, hdkey.publicKey),
+          serialize(
+            hdkey,
+            hdkey.versions.private,
+            Buffer.concat([Buffer.alloc(1, 0), hdkey.privateKey]),
+          ),
         );
-      },
-    });
+      else return null;
+    };
+
+    hdkey.getPublicExtendedKey = function () {
+      return bs58check.encode(
+        serialize(hdkey, hdkey.versions.public, hdkey.publicKey),
+      );
+    };
 
     hdkey.derive = function (path) {
       if (path === "m" || path === "M" || path === "m'" || path === "M'") {
@@ -205,8 +201,8 @@ var HDKey = (globalThis.require && exports) || {};
 
     hdkey.toJSON = function () {
       return {
-        xpriv: hdkey.privateExtendedKey,
-        xpub: hdkey.publicExtendedKey,
+        xpriv: hdkey.getPrivateExtendedKey(),
+        xpub: hdkey.getPublicExtendedKey(),
       };
     };
 

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -30,14 +30,11 @@ var HDKey = (globalThis.require && exports) || {};
     // but used for a different purpose, hence the semantic name
     hdkey.identifier = null;
     hdkey.chainCode = null;
-    hdkey._fingerprint = 0;
     hdkey.parentFingerprint = 0;
 
-    Object.defineProperty(hdkey, "fingerprint", {
-      get: function () {
-        return hdkey._fingerprint;
-      },
-    });
+    hdkey.getFingerprint = function () {
+      return hdkey.identifier.slice(0, 4).readUInt32BE(0);
+    };
 
     hdkey.setPrivateKey = function (value) {
       assert.equal(value.length, 32, "Private key must be 32 bytes.");
@@ -46,7 +43,6 @@ var HDKey = (globalThis.require && exports) || {};
       hdkey.privateKey = value;
       hdkey.publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
       hdkey.identifier = hash160(hdkey.publicKey);
-      hdkey._fingerprint = hdkey.pubKeyHash.slice(0, 4).readUInt32BE(0);
     };
 
     hdkey.setPublicKey = function (value) {
@@ -177,7 +173,7 @@ var HDKey = (globalThis.require && exports) || {};
 
       hd.chainCode = IR;
       hd.depth = hdkey.depth + 1;
-      hd.parentFingerprint = hdkey.fingerprint; // .readUInt32BE(0)
+      hd.parentFingerprint = hdkey.getFingerprint();
       hd.index = index;
 
       return hd;
@@ -298,7 +294,6 @@ var HDKey = (globalThis.require && exports) || {};
   function setPublicKey(hdkey, publicKey) {
     hdkey.publicKey = Buffer.from(publicKey);
     hdkey.identifier = hash160(publicKey);
-    hdkey._fingerprint = hdkey.pubKeyHash.slice(0, 4).readUInt32BE(0);
     hdkey.privateKey = null;
   }
 

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -52,21 +52,23 @@ var HDKey = (globalThis.require && exports) || {};
       );
       assert(secp256k1.publicKeyVerify(value) === true, "Invalid public key");
       // force compressed point (performs public key verification)
-      const publicKey =
+      var publicKey =
         value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
       setPublicKey(hdkey, publicKey);
     };
 
     hdkey.getPrivateExtendedKey = function () {
-      if (hdkey.privateKey)
-        return bs58check.encode(
-          serialize(
-            hdkey,
-            hdkey.versions.private,
-            Buffer.concat([Buffer.alloc(1, 0), hdkey.privateKey]),
-          ),
-        );
-      else return null;
+      if (!hdkey.privateKey) {
+        return null;
+      }
+
+      return bs58check.encode(
+        serialize(
+          hdkey,
+          hdkey.versions.private,
+          Buffer.concat([Buffer.alloc(1, 0), hdkey.privateKey]),
+        ),
+      );
     };
 
     hdkey.getPublicExtendedKey = function () {
@@ -91,7 +93,9 @@ var HDKey = (globalThis.require && exports) || {};
         var hardened = c.length > 1 && c[c.length - 1] === "'";
         var childIndex = parseInt(c, 10); // & (HARDENED_OFFSET - 1)
         assert(childIndex < HARDENED_OFFSET, "Invalid index");
-        if (hardened) childIndex += HARDENED_OFFSET;
+        if (hardened) {
+          childIndex += HARDENED_OFFSET;
+        }
 
         _hdkey = _hdkey.deriveChild(childIndex);
       });
@@ -193,8 +197,9 @@ var HDKey = (globalThis.require && exports) || {};
     };
 
     hdkey.wipePrivateData = function () {
-      if (hdkey.privateKey)
+      if (hdkey.privateKey) {
         crypto.randomBytes(hdkey.privateKey.length).copy(hdkey.privateKey);
+      }
       hdkey.privateKey = null;
       return hdkey;
     };

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -25,7 +25,7 @@ var HDKey = (globalThis.require && exports) || {};
     hdkey.depth = 0;
     hdkey.index = 0;
     hdkey.privateKey = null;
-    hdkey._publicKey = null;
+    hdkey.publicKey = null;
     hdkey.chainCode = null;
     hdkey._fingerprint = 0;
     hdkey.parentFingerprint = 0;
@@ -51,27 +51,22 @@ var HDKey = (globalThis.require && exports) || {};
       assert(secp256k1.privateKeyVerify(value) === true, "Invalid private key");
 
       hdkey.privateKey = value;
-      hdkey._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
+      hdkey.publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
       hdkey._identifier = hash160(hdkey.publicKey);
       hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
     };
 
-    Object.defineProperty(hdkey, "publicKey", {
-      get: function () {
-        return hdkey._publicKey;
-      },
-      set: function (value) {
-        assert(
-          value.length === 33 || value.length === 65,
-          "Public key must be 33 or 65 bytes.",
-        );
-        assert(secp256k1.publicKeyVerify(value) === true, "Invalid public key");
-        // force compressed point (performs public key verification)
-        const publicKey =
-          value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
-        setPublicKey(hdkey, publicKey);
-      },
-    });
+    hdkey.setPublicKey = function (value) {
+      assert(
+        value.length === 33 || value.length === 65,
+        "Public key must be 33 or 65 bytes.",
+      );
+      assert(secp256k1.publicKeyVerify(value) === true, "Invalid public key");
+      // force compressed point (performs public key verification)
+      const publicKey =
+        value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
+      setPublicKey(hdkey, publicKey);
+    };
 
     Object.defineProperty(hdkey, "privateExtendedKey", {
       get: function () {
@@ -171,8 +166,14 @@ var HDKey = (globalThis.require && exports) || {};
         // Ki = point(parse256(IL)) + Kpar
         //    = G*IL + Kpar
         try {
-          hd.publicKey = Buffer.from(
-            secp256k1.publicKeyTweakAdd(Buffer.from(hdkey.publicKey), IL, true),
+          hd.setPublicKey(
+            Buffer.from(
+              secp256k1.publicKeyTweakAdd(
+                Buffer.from(hdkey.publicKey),
+                IL,
+                true,
+              ),
+            ),
           );
           // throw if IL >= n || (g**IL + publicKey) is infinity
         } catch (err) {
@@ -273,7 +274,7 @@ var HDKey = (globalThis.require && exports) || {};
       if (skipVerification) {
         setPublicKey(hdkey, key);
       } else {
-        hdkey.publicKey = key;
+        hdkey.setPublicKey(key);
       }
     }
 
@@ -302,7 +303,7 @@ var HDKey = (globalThis.require && exports) || {};
   }
 
   function setPublicKey(hdkey, publicKey) {
-    hdkey._publicKey = Buffer.from(publicKey);
+    hdkey.publicKey = Buffer.from(publicKey);
     hdkey._identifier = hash160(publicKey);
     hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
     hdkey.privateKey = null;

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -158,7 +158,7 @@ var HDKey = (globalThis.require && exports) || {};
 
       if (isHardened) {
         // Hardened child
-        assert(_privateKey, "Could not derive hardened child key");
+        assert(Boolean(_privateKey), "Could not derive hardened child key");
 
         let pk = _privateKey;
         let zb = Buffer.alloc(1, 0);

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -41,24 +41,24 @@ var HDKey = (globalThis.require && exports) || {};
 (function (window, HDKey) {
   "use strict";
 
-  var Buffer = require("safe-buffer").Buffer;
-  var crypto = require("crypto");
-  var bs58check = require("bs58check");
-  var RIPEMD160 = require("ripemd160");
-  var secp256k1 = require("secp256k1");
+  let Buffer = require("safe-buffer").Buffer;
+  let crypto = require("crypto");
+  let bs58check = require("bs58check");
+  let RIPEMD160 = require("ripemd160");
+  let secp256k1 = require("secp256k1");
 
-  var MASTER_SECRET = Buffer.from("Bitcoin seed", "utf8");
-  var HARDENED_OFFSET = 0x80000000;
-  var LEN = 78;
+  let MASTER_SECRET = Buffer.from("Bitcoin seed", "utf8");
+  let HARDENED_OFFSET = 0x80000000;
+  let LEN = 78;
 
   // Bitcoin hardcoded by default, can use package `coininfo` for others
-  var BITCOIN_VERSIONS = { private: 0x0488ade4, public: 0x0488b21e };
+  let BITCOIN_VERSIONS = { private: 0x0488ade4, public: 0x0488b21e };
 
   HDKey.create = function (versions) {
     /** @type {hdkey} */
-    var hdkey = {};
+    let hdkey = {};
     /** @type {Uint8Array?} */
-    var _privateKey = null;
+    let _privateKey = null;
 
     hdkey.versions = versions || BITCOIN_VERSIONS;
     hdkey.depth = 0;
@@ -91,7 +91,7 @@ var HDKey = (globalThis.require && exports) || {};
       );
       assert(secp256k1.publicKeyVerify(value) === true, "Invalid public key");
       // force compressed point (performs public key verification)
-      var publicKey =
+      let publicKey =
         value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
       hdkey._setPublicKey(publicKey);
     };
@@ -128,16 +128,16 @@ var HDKey = (globalThis.require && exports) || {};
       }
 
       // m, 44', 5', 0, 0, 0
-      var entries = path.split("/");
-      var _hdkey = hdkey;
+      let entries = path.split("/");
+      let _hdkey = hdkey;
       entries.forEach(function (c, i) {
         if (i === 0) {
           assert(/^[mM]{1}/.test(c), 'Path must start with "m" or "M"');
           return;
         }
 
-        var hardened = c.length > 1 && c[c.length - 1] === "'";
-        var childIndex = parseInt(c, 10); // & (HARDENED_OFFSET - 1)
+        let hardened = c.length > 1 && c[c.length - 1] === "'";
+        let childIndex = parseInt(c, 10); // & (HARDENED_OFFSET - 1)
         assert(childIndex < HARDENED_OFFSET, "Invalid index");
         if (hardened) {
           childIndex += HARDENED_OFFSET;
@@ -150,18 +150,18 @@ var HDKey = (globalThis.require && exports) || {};
     };
 
     hdkey.deriveChild = function (index) {
-      var isHardened = index >= HARDENED_OFFSET;
-      var indexBuffer = Buffer.allocUnsafe(4);
+      let isHardened = index >= HARDENED_OFFSET;
+      let indexBuffer = Buffer.allocUnsafe(4);
       indexBuffer.writeUInt32BE(index, 0);
 
-      var data;
+      let data;
 
       if (isHardened) {
         // Hardened child
         assert(_privateKey, "Could not derive hardened child key");
 
-        var pk = _privateKey;
-        var zb = Buffer.alloc(1, 0);
+        let pk = _privateKey;
+        let zb = Buffer.alloc(1, 0);
         pk = Buffer.concat([zb, pk]);
 
         // data = 0x00 || ser256(kpar) || ser32(index)
@@ -173,14 +173,14 @@ var HDKey = (globalThis.require && exports) || {};
         data = Buffer.concat([hdkey.publicKey, indexBuffer]);
       }
 
-      var I = crypto
+      let I = crypto
         .createHmac("sha512", hdkey.chainCode)
         .update(data)
         .digest();
-      var IL = I.slice(0, 32);
-      var IR = I.slice(32);
+      let IL = I.slice(0, 32);
+      let IR = I.slice(32);
 
-      var hd = HDKey.create(hdkey.versions);
+      let hd = HDKey.create(hdkey.versions);
 
       // Private parent key -> private child key
       if (_privateKey) {
@@ -259,14 +259,14 @@ var HDKey = (globalThis.require && exports) || {};
   };
 
   HDKey.fromMasterSeed = function (seedBuffer, versions) {
-    var I = crypto
+    let I = crypto
       .createHmac("sha512", MASTER_SECRET)
       .update(seedBuffer)
       .digest();
-    var IL = I.slice(0, 32);
-    var IR = I.slice(32);
+    let IL = I.slice(0, 32);
+    let IR = I.slice(32);
 
-    var hdkey = HDKey.create(versions);
+    let hdkey = HDKey.create(versions);
     hdkey.chainCode = IR;
     hdkey.setPrivateKey(IL);
 
@@ -277,11 +277,11 @@ var HDKey = (globalThis.require && exports) || {};
     // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
     versions = versions || BITCOIN_VERSIONS;
     skipVerification = skipVerification || false;
-    var hdkey = HDKey.create(versions);
+    let hdkey = HDKey.create(versions);
 
-    var keyBuffer = bs58check.decode(base58key);
+    let keyBuffer = bs58check.decode(base58key);
 
-    var version = keyBuffer.readUInt32BE(0);
+    let version = keyBuffer.readUInt32BE(0);
     assert(
       version === versions.private || version === versions.public,
       "Version mismatch: does not match private or public",
@@ -292,7 +292,7 @@ var HDKey = (globalThis.require && exports) || {};
     hdkey.index = keyBuffer.readUInt32BE(9);
     hdkey.chainCode = keyBuffer.slice(13, 45);
 
-    var key = keyBuffer.slice(45);
+    let key = keyBuffer.slice(45);
     if (key.readUInt8(0) === 0) {
       // private
       assert(
@@ -336,12 +336,12 @@ var HDKey = (globalThis.require && exports) || {};
    */
   function serialize(hdkey, version, key) {
     // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
-    var buffer = Buffer.allocUnsafe(LEN);
+    let buffer = Buffer.allocUnsafe(LEN);
 
     buffer.writeUInt32BE(version, 0);
     buffer.writeUInt8(hdkey.depth, 4);
 
-    var fingerprint = hdkey.depth ? hdkey.parentFingerprint : 0x00000000;
+    let fingerprint = hdkey.depth ? hdkey.parentFingerprint : 0x00000000;
     buffer.writeUInt32BE(fingerprint, 5);
     buffer.writeUInt32BE(hdkey.index, 9);
 
@@ -355,7 +355,7 @@ var HDKey = (globalThis.require && exports) || {};
    * @param {Uint8Array} buf
    */
   function hash160(buf) {
-    var sha = crypto.createHash("sha256").update(buf).digest();
+    let sha = crypto.createHash("sha256").update(buf).digest();
     return new RIPEMD160().update(sha).digest();
   }
 

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -1,7 +1,7 @@
-/** @type {HDKEY} */
+/** @type {HDKey} */
 //@ts-ignore
-var HDKEY = (globalThis.require && exports) || {};
-(function (window, HDKEY) {
+var HDKey = (globalThis.require && exports) || {};
+(function (window, HDKey) {
   "use strict";
 
   var assert = require("assert");
@@ -18,8 +18,8 @@ var HDKEY = (globalThis.require && exports) || {};
   // Bitcoin hardcoded by default, can use package `coininfo` for others
   var BITCOIN_VERSIONS = { private: 0x0488ade4, public: 0x0488b21e };
 
-  HDKEY.create = function (versions) {
-    let hdkey = {};
+  HDKey.create = function (versions) {
+    var hdkey = {};
 
     hdkey.versions = versions || BITCOIN_VERSIONS;
     hdkey.depth = 0;
@@ -158,7 +158,7 @@ var HDKEY = (globalThis.require && exports) || {};
       var IL = I.slice(0, 32);
       var IR = I.slice(32);
 
-      var hd = HDKEY.create(hdkey.versions);
+      var hd = HDKey.create(hdkey.versions);
 
       // Private parent key -> private child key
       if (hdkey.privateKey) {
@@ -229,7 +229,7 @@ var HDKEY = (globalThis.require && exports) || {};
     return hdkey;
   };
 
-  HDKEY.fromMasterSeed = function (seedBuffer, versions) {
+  HDKey.fromMasterSeed = function (seedBuffer, versions) {
     var I = crypto
       .createHmac("sha512", MASTER_SECRET)
       .update(seedBuffer)
@@ -237,18 +237,18 @@ var HDKEY = (globalThis.require && exports) || {};
     var IL = I.slice(0, 32);
     var IR = I.slice(32);
 
-    var hdkey = HDKEY.create(versions);
+    var hdkey = HDKey.create(versions);
     hdkey.chainCode = IR;
     hdkey.privateKey = IL;
 
     return hdkey;
   };
 
-  HDKEY.fromExtendedKey = function (base58key, versions, skipVerification) {
+  HDKey.fromExtendedKey = function (base58key, versions, skipVerification) {
     // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
     versions = versions || BITCOIN_VERSIONS;
     skipVerification = skipVerification || false;
-    var hdkey = HDKEY.create(versions);
+    var hdkey = HDKey.create(versions);
 
     var keyBuffer = bs58check.decode(base58key);
 
@@ -286,8 +286,8 @@ var HDKEY = (globalThis.require && exports) || {};
     return hdkey;
   };
 
-  HDKEY.fromJSON = function (obj) {
-    return HDKEY.fromExtendedKey(obj.xpriv);
+  HDKey.fromJSON = function (obj) {
+    return HDKey.fromExtendedKey(obj.xpriv);
   };
 
   function serialize(hdkey, version, key) {
@@ -319,8 +319,8 @@ var HDKEY = (globalThis.require && exports) || {};
     return new RIPEMD160().update(sha).digest();
   }
 
-  HDKEY.HARDENED_OFFSET = HARDENED_OFFSET;
-})(globalThis.window || {}, HDKEY);
+  HDKey.HARDENED_OFFSET = HARDENED_OFFSET;
+})(globalThis.window || {}, HDKey);
 if ("object" === typeof module) {
-  module.exports = HDKEY;
+  module.exports = HDKey;
 }

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -24,7 +24,7 @@ var HDKey = (globalThis.require && exports) || {};
     hdkey.versions = versions || BITCOIN_VERSIONS;
     hdkey.depth = 0;
     hdkey.index = 0;
-    hdkey._privateKey = null;
+    hdkey.privateKey = null;
     hdkey._publicKey = null;
     hdkey.chainCode = null;
     hdkey._fingerprint = 0;
@@ -46,23 +46,15 @@ var HDKey = (globalThis.require && exports) || {};
       },
     });
 
-    Object.defineProperty(hdkey, "privateKey", {
-      get: function () {
-        return hdkey._privateKey;
-      },
-      set: function (value) {
-        assert.equal(value.length, 32, "Private key must be 32 bytes.");
-        assert(
-          secp256k1.privateKeyVerify(value) === true,
-          "Invalid private key",
-        );
+    hdkey.setPrivateKey = function (value) {
+      assert.equal(value.length, 32, "Private key must be 32 bytes.");
+      assert(secp256k1.privateKeyVerify(value) === true, "Invalid private key");
 
-        hdkey._privateKey = value;
-        hdkey._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
-        hdkey._identifier = hash160(hdkey.publicKey);
-        hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
-      },
-    });
+      hdkey.privateKey = value;
+      hdkey._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
+      hdkey._identifier = hash160(hdkey.publicKey);
+      hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
+    };
 
     Object.defineProperty(hdkey, "publicKey", {
       get: function () {
@@ -83,7 +75,7 @@ var HDKey = (globalThis.require && exports) || {};
 
     Object.defineProperty(hdkey, "privateExtendedKey", {
       get: function () {
-        if (hdkey._privateKey)
+        if (hdkey.privateKey)
           return bs58check.encode(
             serialize(
               hdkey,
@@ -164,8 +156,10 @@ var HDKey = (globalThis.require && exports) || {};
       if (hdkey.privateKey) {
         // ki = parse256(IL) + kpar (mod n)
         try {
-          hd.privateKey = Buffer.from(
-            secp256k1.privateKeyTweakAdd(Buffer.from(hdkey.privateKey), IL),
+          hd.setPrivateKey(
+            Buffer.from(
+              secp256k1.privateKeyTweakAdd(Buffer.from(hdkey.privateKey), IL),
+            ),
           );
           // throw if IL >= n || (privateKey + IL) === 0
         } catch (err) {
@@ -213,9 +207,9 @@ var HDKey = (globalThis.require && exports) || {};
     };
 
     hdkey.wipePrivateData = function () {
-      if (hdkey._privateKey)
-        crypto.randomBytes(hdkey._privateKey.length).copy(hdkey._privateKey);
-      hdkey._privateKey = null;
+      if (hdkey.privateKey)
+        crypto.randomBytes(hdkey.privateKey.length).copy(hdkey.privateKey);
+      hdkey.privateKey = null;
       return hdkey;
     };
 
@@ -239,7 +233,7 @@ var HDKey = (globalThis.require && exports) || {};
 
     var hdkey = HDKey.create(versions);
     hdkey.chainCode = IR;
-    hdkey.privateKey = IL;
+    hdkey.setPrivateKey(IL);
 
     return hdkey;
   };
@@ -270,7 +264,7 @@ var HDKey = (globalThis.require && exports) || {};
         version === versions.private,
         "Version mismatch: version does not match private",
       );
-      hdkey.privateKey = key.slice(1); // cut off first 0x0 byte
+      hdkey.setPrivateKey(key.slice(1)); // cut off first 0x0 byte
     } else {
       assert(
         version === versions.public,
@@ -311,7 +305,7 @@ var HDKey = (globalThis.require && exports) || {};
     hdkey._publicKey = Buffer.from(publicKey);
     hdkey._identifier = hash160(publicKey);
     hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
-    hdkey._privateKey = null;
+    hdkey.privateKey = null;
   }
 
   function hash160(buf) {

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -19,36 +19,36 @@ var HDKEY = (globalThis.require && exports) || {};
   var BITCOIN_VERSIONS = { private: 0x0488ade4, public: 0x0488b21e };
 
   HDKEY.create = function (versions) {
-    function HDKey(versions) {
-      this.versions = versions || BITCOIN_VERSIONS;
-      this.depth = 0;
-      this.index = 0;
-      this._privateKey = null;
-      this._publicKey = null;
-      this.chainCode = null;
-      this._fingerprint = 0;
-      this.parentFingerprint = 0;
-    }
+    let hdkey = {};
 
-    Object.defineProperty(HDKey.prototype, "fingerprint", {
+    hdkey.versions = versions || BITCOIN_VERSIONS;
+    hdkey.depth = 0;
+    hdkey.index = 0;
+    hdkey._privateKey = null;
+    hdkey._publicKey = null;
+    hdkey.chainCode = null;
+    hdkey._fingerprint = 0;
+    hdkey.parentFingerprint = 0;
+
+    Object.defineProperty(hdkey, "fingerprint", {
       get: function () {
-        return this._fingerprint;
+        return hdkey._fingerprint;
       },
     });
-    Object.defineProperty(HDKey.prototype, "identifier", {
+    Object.defineProperty(hdkey, "identifier", {
       get: function () {
-        return this._identifier;
+        return hdkey._identifier;
       },
     });
-    Object.defineProperty(HDKey.prototype, "pubKeyHash", {
+    Object.defineProperty(hdkey, "pubKeyHash", {
       get: function () {
-        return this.identifier;
+        return hdkey.identifier;
       },
     });
 
-    Object.defineProperty(HDKey.prototype, "privateKey", {
+    Object.defineProperty(hdkey, "privateKey", {
       get: function () {
-        return this._privateKey;
+        return hdkey._privateKey;
       },
       set: function (value) {
         assert.equal(value.length, 32, "Private key must be 32 bytes.");
@@ -57,16 +57,16 @@ var HDKEY = (globalThis.require && exports) || {};
           "Invalid private key",
         );
 
-        this._privateKey = value;
-        this._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
-        this._identifier = hash160(this.publicKey);
-        this._fingerprint = this._identifier.slice(0, 4).readUInt32BE(0);
+        hdkey._privateKey = value;
+        hdkey._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
+        hdkey._identifier = hash160(hdkey.publicKey);
+        hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
       },
     });
 
-    Object.defineProperty(HDKey.prototype, "publicKey", {
+    Object.defineProperty(hdkey, "publicKey", {
       get: function () {
-        return this._publicKey;
+        return hdkey._publicKey;
       },
       set: function (value) {
         assert(
@@ -77,39 +77,39 @@ var HDKEY = (globalThis.require && exports) || {};
         // force compressed point (performs public key verification)
         const publicKey =
           value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
-        setPublicKey(this, publicKey);
+        setPublicKey(hdkey, publicKey);
       },
     });
 
-    Object.defineProperty(HDKey.prototype, "privateExtendedKey", {
+    Object.defineProperty(hdkey, "privateExtendedKey", {
       get: function () {
-        if (this._privateKey)
+        if (hdkey._privateKey)
           return bs58check.encode(
             serialize(
-              this,
-              this.versions.private,
-              Buffer.concat([Buffer.alloc(1, 0), this.privateKey]),
+              hdkey,
+              hdkey.versions.private,
+              Buffer.concat([Buffer.alloc(1, 0), hdkey.privateKey]),
             ),
           );
         else return null;
       },
     });
 
-    Object.defineProperty(HDKey.prototype, "publicExtendedKey", {
+    Object.defineProperty(hdkey, "publicExtendedKey", {
       get: function () {
         return bs58check.encode(
-          serialize(this, this.versions.public, this.publicKey),
+          serialize(hdkey, hdkey.versions.public, hdkey.publicKey),
         );
       },
     });
 
-    HDKey.prototype.derive = function (path) {
+    hdkey.derive = function (path) {
       if (path === "m" || path === "M" || path === "m'" || path === "M'") {
-        return this;
+        return hdkey;
       }
 
       var entries = path.split("/");
-      var hdkey = this;
+      var _hdkey = hdkey;
       entries.forEach(function (c, i) {
         if (i === 0) {
           assert(/^[mM]{1}/.test(c), 'Path must start with "m" or "M"');
@@ -121,13 +121,13 @@ var HDKEY = (globalThis.require && exports) || {};
         assert(childIndex < HARDENED_OFFSET, "Invalid index");
         if (hardened) childIndex += HARDENED_OFFSET;
 
-        hdkey = hdkey.deriveChild(childIndex);
+        _hdkey = _hdkey.deriveChild(childIndex);
       });
 
-      return hdkey;
+      return _hdkey;
     };
 
-    HDKey.prototype.deriveChild = function (index) {
+    hdkey.deriveChild = function (index) {
       var isHardened = index >= HARDENED_OFFSET;
       var indexBuffer = Buffer.allocUnsafe(4);
       indexBuffer.writeUInt32BE(index, 0);
@@ -136,9 +136,9 @@ var HDKEY = (globalThis.require && exports) || {};
 
       if (isHardened) {
         // Hardened child
-        assert(this.privateKey, "Could not derive hardened child key");
+        assert(hdkey.privateKey, "Could not derive hardened child key");
 
-        var pk = this.privateKey;
+        var pk = hdkey.privateKey;
         var zb = Buffer.alloc(1, 0);
         pk = Buffer.concat([zb, pk]);
 
@@ -148,26 +148,29 @@ var HDKEY = (globalThis.require && exports) || {};
         // Normal child
         // data = serP(point(kpar)) || ser32(index)
         //      = serP(Kpar) || ser32(index)
-        data = Buffer.concat([this.publicKey, indexBuffer]);
+        data = Buffer.concat([hdkey.publicKey, indexBuffer]);
       }
 
-      var I = crypto.createHmac("sha512", this.chainCode).update(data).digest();
+      var I = crypto
+        .createHmac("sha512", hdkey.chainCode)
+        .update(data)
+        .digest();
       var IL = I.slice(0, 32);
       var IR = I.slice(32);
 
-      var hd = HDKEY.create(this.versions);
+      var hd = HDKEY.create(hdkey.versions);
 
       // Private parent key -> private child key
-      if (this.privateKey) {
+      if (hdkey.privateKey) {
         // ki = parse256(IL) + kpar (mod n)
         try {
           hd.privateKey = Buffer.from(
-            secp256k1.privateKeyTweakAdd(Buffer.from(this.privateKey), IL),
+            secp256k1.privateKeyTweakAdd(Buffer.from(hdkey.privateKey), IL),
           );
           // throw if IL >= n || (privateKey + IL) === 0
         } catch (err) {
           // In case parse256(IL) >= n or ki == 0, one should proceed with the next value for i
-          return this.deriveChild(index + 1);
+          return hdkey.deriveChild(index + 1);
         }
         // Public parent key -> public child key
       } else {
@@ -175,55 +178,55 @@ var HDKEY = (globalThis.require && exports) || {};
         //    = G*IL + Kpar
         try {
           hd.publicKey = Buffer.from(
-            secp256k1.publicKeyTweakAdd(Buffer.from(this.publicKey), IL, true),
+            secp256k1.publicKeyTweakAdd(Buffer.from(hdkey.publicKey), IL, true),
           );
           // throw if IL >= n || (g**IL + publicKey) is infinity
         } catch (err) {
           // In case parse256(IL) >= n or Ki is the point at infinity, one should proceed with the next value for i
-          return this.deriveChild(index + 1);
+          return hdkey.deriveChild(index + 1);
         }
       }
 
       hd.chainCode = IR;
-      hd.depth = this.depth + 1;
-      hd.parentFingerprint = this.fingerprint; // .readUInt32BE(0)
+      hd.depth = hdkey.depth + 1;
+      hd.parentFingerprint = hdkey.fingerprint; // .readUInt32BE(0)
       hd.index = index;
 
       return hd;
     };
 
-    HDKey.prototype.sign = function (hash) {
+    hdkey.sign = function (hash) {
       return Buffer.from(
         secp256k1.ecdsaSign(
           Uint8Array.from(hash),
-          Uint8Array.from(this.privateKey),
+          Uint8Array.from(hdkey.privateKey),
         ).signature,
       );
     };
 
-    HDKey.prototype.verify = function (hash, signature) {
+    hdkey.verify = function (hash, signature) {
       return secp256k1.ecdsaVerify(
         Uint8Array.from(signature),
         Uint8Array.from(hash),
-        Uint8Array.from(this.publicKey),
+        Uint8Array.from(hdkey.publicKey),
       );
     };
 
-    HDKey.prototype.wipePrivateData = function () {
-      if (this._privateKey)
-        crypto.randomBytes(this._privateKey.length).copy(this._privateKey);
-      this._privateKey = null;
-      return this;
+    hdkey.wipePrivateData = function () {
+      if (hdkey._privateKey)
+        crypto.randomBytes(hdkey._privateKey.length).copy(hdkey._privateKey);
+      hdkey._privateKey = null;
+      return hdkey;
     };
 
-    HDKey.prototype.toJSON = function () {
+    hdkey.toJSON = function () {
       return {
-        xpriv: this.privateExtendedKey,
-        xpub: this.publicExtendedKey,
+        xpriv: hdkey.privateExtendedKey,
+        xpub: hdkey.publicExtendedKey,
       };
     };
 
-    return new HDKey(versions);
+    return hdkey;
   };
 
   HDKEY.fromMasterSeed = function (seedBuffer, versions) {

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -4,7 +4,6 @@ var HDKey = (globalThis.require && exports) || {};
 (function (window, HDKey) {
   "use strict";
 
-  var assert = require("assert");
   var Buffer = require("safe-buffer").Buffer;
   var crypto = require("crypto");
   var bs58check = require("bs58check");
@@ -41,7 +40,7 @@ var HDKey = (globalThis.require && exports) || {};
       return _privateKey;
     };
     hdkey.setPrivateKey = function (value) {
-      assert.equal(value.length, 32, "Private key must be 32 bytes.");
+      assert(value.length === 32, "Private key must be 32 bytes.");
       assert(secp256k1.privateKeyVerify(value) === true, "Invalid private key");
 
       _privateKey = value;
@@ -282,6 +281,12 @@ var HDKey = (globalThis.require && exports) || {};
   HDKey.fromJSON = function (obj) {
     return HDKey.fromExtendedKey(obj.xpriv);
   };
+
+  function assert(assertion, message) {
+    if (!assertion) {
+      throw new Error(message);
+    }
+  }
 
   function serialize(hdkey, version, key) {
     // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -20,15 +20,16 @@ var HDKey = (globalThis.require && exports) || {};
 
   HDKey.create = function (versions) {
     var hdkey = {};
+    var _privateKey = null;
 
     hdkey.versions = versions || BITCOIN_VERSIONS;
     hdkey.depth = 0;
     hdkey.index = 0;
-    hdkey.privateKey = null;
     hdkey.publicKey = null;
     // note: BIP-32 "Key Identifier" is the same as "Pub Key Hash"
     // but used for a different purpose, hence the semantic name
     hdkey.identifier = null;
+    // note: chainCode is public
     hdkey.chainCode = null;
     hdkey.parentFingerprint = 0;
 
@@ -36,11 +37,14 @@ var HDKey = (globalThis.require && exports) || {};
       return hdkey.identifier.slice(0, 4).readUInt32BE(0);
     };
 
+    hdkey.getPrivateKey = function () {
+      return _privateKey;
+    };
     hdkey.setPrivateKey = function (value) {
       assert.equal(value.length, 32, "Private key must be 32 bytes.");
       assert(secp256k1.privateKeyVerify(value) === true, "Invalid private key");
 
-      hdkey.privateKey = value;
+      _privateKey = value;
       hdkey.publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
       hdkey.identifier = hash160(hdkey.publicKey);
     };
@@ -54,11 +58,17 @@ var HDKey = (globalThis.require && exports) || {};
       // force compressed point (performs public key verification)
       var publicKey =
         value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
-      setPublicKey(hdkey, publicKey);
+      hdkey._setPublicKey(publicKey);
+    };
+
+    hdkey._setPublicKey = function (publicKey) {
+      hdkey.publicKey = Buffer.from(publicKey);
+      hdkey.identifier = hash160(publicKey);
+      _privateKey = null;
     };
 
     hdkey.getPrivateExtendedKey = function () {
-      if (!hdkey.privateKey) {
+      if (!_privateKey) {
         return null;
       }
 
@@ -66,7 +76,7 @@ var HDKey = (globalThis.require && exports) || {};
         serialize(
           hdkey,
           hdkey.versions.private,
-          Buffer.concat([Buffer.alloc(1, 0), hdkey.privateKey]),
+          Buffer.concat([Buffer.alloc(1, 0), _privateKey]),
         ),
       );
     };
@@ -112,9 +122,9 @@ var HDKey = (globalThis.require && exports) || {};
 
       if (isHardened) {
         // Hardened child
-        assert(hdkey.privateKey, "Could not derive hardened child key");
+        assert(_privateKey, "Could not derive hardened child key");
 
-        var pk = hdkey.privateKey;
+        var pk = _privateKey;
         var zb = Buffer.alloc(1, 0);
         pk = Buffer.concat([zb, pk]);
 
@@ -137,12 +147,12 @@ var HDKey = (globalThis.require && exports) || {};
       var hd = HDKey.create(hdkey.versions);
 
       // Private parent key -> private child key
-      if (hdkey.privateKey) {
+      if (_privateKey) {
         // ki = parse256(IL) + kpar (mod n)
         try {
           hd.setPrivateKey(
             Buffer.from(
-              secp256k1.privateKeyTweakAdd(Buffer.from(hdkey.privateKey), IL),
+              secp256k1.privateKeyTweakAdd(Buffer.from(_privateKey), IL),
             ),
           );
           // throw if IL >= n || (privateKey + IL) === 0
@@ -181,10 +191,8 @@ var HDKey = (globalThis.require && exports) || {};
 
     hdkey.sign = function (hash) {
       return Buffer.from(
-        secp256k1.ecdsaSign(
-          Uint8Array.from(hash),
-          Uint8Array.from(hdkey.privateKey),
-        ).signature,
+        secp256k1.ecdsaSign(Uint8Array.from(hash), Uint8Array.from(_privateKey))
+          .signature,
       );
     };
 
@@ -197,10 +205,10 @@ var HDKey = (globalThis.require && exports) || {};
     };
 
     hdkey.wipePrivateData = function () {
-      if (hdkey.privateKey) {
-        crypto.randomBytes(hdkey.privateKey.length).copy(hdkey.privateKey);
+      if (_privateKey) {
+        crypto.randomBytes(_privateKey.length).copy(_privateKey);
       }
-      hdkey.privateKey = null;
+      _privateKey = null;
       return hdkey;
     };
 
@@ -262,7 +270,7 @@ var HDKey = (globalThis.require && exports) || {};
         "Version mismatch: version does not match public",
       );
       if (skipVerification) {
-        setPublicKey(hdkey, key);
+        hdkey._setPublicKey(key);
       } else {
         hdkey.setPublicKey(key);
       }
@@ -290,12 +298,6 @@ var HDKey = (globalThis.require && exports) || {};
     key.copy(buffer, 45);
 
     return buffer;
-  }
-
-  function setPublicKey(hdkey, publicKey) {
-    hdkey.publicKey = Buffer.from(publicKey);
-    hdkey.identifier = hash160(publicKey);
-    hdkey.privateKey = null;
   }
 
   function hash160(buf) {

--- a/lib/hdkey.js
+++ b/lib/hdkey.js
@@ -1,307 +1,320 @@
-"use strict";
+/** @type {HDKEY} */
+//@ts-ignore
+var HDKEY = (globalThis.require && exports) || {};
+(function (window, HDKEY) {
+  "use strict";
 
-var assert = require("assert");
-var Buffer = require("safe-buffer").Buffer;
-var crypto = require("crypto");
-var bs58check = require("bs58check");
-var RIPEMD160 = require("ripemd160");
-var secp256k1 = require("secp256k1");
+  var assert = require("assert");
+  var Buffer = require("safe-buffer").Buffer;
+  var crypto = require("crypto");
+  var bs58check = require("bs58check");
+  var RIPEMD160 = require("ripemd160");
+  var secp256k1 = require("secp256k1");
 
-var MASTER_SECRET = Buffer.from("Bitcoin seed", "utf8");
-var HARDENED_OFFSET = 0x80000000;
-var LEN = 78;
+  var MASTER_SECRET = Buffer.from("Bitcoin seed", "utf8");
+  var HARDENED_OFFSET = 0x80000000;
+  var LEN = 78;
 
-// Bitcoin hardcoded by default, can use package `coininfo` for others
-var BITCOIN_VERSIONS = { private: 0x0488ade4, public: 0x0488b21e };
+  // Bitcoin hardcoded by default, can use package `coininfo` for others
+  var BITCOIN_VERSIONS = { private: 0x0488ade4, public: 0x0488b21e };
 
-function HDKey(versions) {
-  this.versions = versions || BITCOIN_VERSIONS;
-  this.depth = 0;
-  this.index = 0;
-  this._privateKey = null;
-  this._publicKey = null;
-  this.chainCode = null;
-  this._fingerprint = 0;
-  this.parentFingerprint = 0;
-}
+  HDKEY.create = function (versions) {
+    return new HDKey(versions);
+  };
 
-Object.defineProperty(HDKey.prototype, "fingerprint", {
-  get: function () {
-    return this._fingerprint;
-  },
-});
-Object.defineProperty(HDKey.prototype, "identifier", {
-  get: function () {
-    return this._identifier;
-  },
-});
-Object.defineProperty(HDKey.prototype, "pubKeyHash", {
-  get: function () {
-    return this.identifier;
-  },
-});
-
-Object.defineProperty(HDKey.prototype, "privateKey", {
-  get: function () {
-    return this._privateKey;
-  },
-  set: function (value) {
-    assert.equal(value.length, 32, "Private key must be 32 bytes.");
-    assert(secp256k1.privateKeyVerify(value) === true, "Invalid private key");
-
-    this._privateKey = value;
-    this._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
-    this._identifier = hash160(this.publicKey);
-    this._fingerprint = this._identifier.slice(0, 4).readUInt32BE(0);
-  },
-});
-
-function setPublicKey(hdkey, publicKey) {
-  hdkey._publicKey = Buffer.from(publicKey);
-  hdkey._identifier = hash160(publicKey);
-  hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
-  hdkey._privateKey = null;
-}
-
-Object.defineProperty(HDKey.prototype, "publicKey", {
-  get: function () {
-    return this._publicKey;
-  },
-  set: function (value) {
-    assert(
-      value.length === 33 || value.length === 65,
-      "Public key must be 33 or 65 bytes.",
-    );
-    assert(secp256k1.publicKeyVerify(value) === true, "Invalid public key");
-    // force compressed point (performs public key verification)
-    const publicKey =
-      value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
-    setPublicKey(this, publicKey);
-  },
-});
-
-Object.defineProperty(HDKey.prototype, "privateExtendedKey", {
-  get: function () {
-    if (this._privateKey)
-      return bs58check.encode(
-        serialize(
-          this,
-          this.versions.private,
-          Buffer.concat([Buffer.alloc(1, 0), this.privateKey]),
-        ),
-      );
-    else return null;
-  },
-});
-
-Object.defineProperty(HDKey.prototype, "publicExtendedKey", {
-  get: function () {
-    return bs58check.encode(
-      serialize(this, this.versions.public, this.publicKey),
-    );
-  },
-});
-
-HDKey.prototype.derive = function (path) {
-  if (path === "m" || path === "M" || path === "m'" || path === "M'") {
-    return this;
+  function HDKey(versions) {
+    this.versions = versions || BITCOIN_VERSIONS;
+    this.depth = 0;
+    this.index = 0;
+    this._privateKey = null;
+    this._publicKey = null;
+    this.chainCode = null;
+    this._fingerprint = 0;
+    this.parentFingerprint = 0;
   }
 
-  var entries = path.split("/");
-  var hdkey = this;
-  entries.forEach(function (c, i) {
-    if (i === 0) {
-      assert(/^[mM]{1}/.test(c), 'Path must start with "m" or "M"');
-      return;
-    }
-
-    var hardened = c.length > 1 && c[c.length - 1] === "'";
-    var childIndex = parseInt(c, 10); // & (HARDENED_OFFSET - 1)
-    assert(childIndex < HARDENED_OFFSET, "Invalid index");
-    if (hardened) childIndex += HARDENED_OFFSET;
-
-    hdkey = hdkey.deriveChild(childIndex);
+  Object.defineProperty(HDKey.prototype, "fingerprint", {
+    get: function () {
+      return this._fingerprint;
+    },
+  });
+  Object.defineProperty(HDKey.prototype, "identifier", {
+    get: function () {
+      return this._identifier;
+    },
+  });
+  Object.defineProperty(HDKey.prototype, "pubKeyHash", {
+    get: function () {
+      return this.identifier;
+    },
   });
 
-  return hdkey;
-};
+  Object.defineProperty(HDKey.prototype, "privateKey", {
+    get: function () {
+      return this._privateKey;
+    },
+    set: function (value) {
+      assert.equal(value.length, 32, "Private key must be 32 bytes.");
+      assert(secp256k1.privateKeyVerify(value) === true, "Invalid private key");
 
-HDKey.prototype.deriveChild = function (index) {
-  var isHardened = index >= HARDENED_OFFSET;
-  var indexBuffer = Buffer.allocUnsafe(4);
-  indexBuffer.writeUInt32BE(index, 0);
+      this._privateKey = value;
+      this._publicKey = Buffer.from(secp256k1.publicKeyCreate(value, true));
+      this._identifier = hash160(this.publicKey);
+      this._fingerprint = this._identifier.slice(0, 4).readUInt32BE(0);
+    },
+  });
 
-  var data;
-
-  if (isHardened) {
-    // Hardened child
-    assert(this.privateKey, "Could not derive hardened child key");
-
-    var pk = this.privateKey;
-    var zb = Buffer.alloc(1, 0);
-    pk = Buffer.concat([zb, pk]);
-
-    // data = 0x00 || ser256(kpar) || ser32(index)
-    data = Buffer.concat([pk, indexBuffer]);
-  } else {
-    // Normal child
-    // data = serP(point(kpar)) || ser32(index)
-    //      = serP(Kpar) || ser32(index)
-    data = Buffer.concat([this.publicKey, indexBuffer]);
-  }
-
-  var I = crypto.createHmac("sha512", this.chainCode).update(data).digest();
-  var IL = I.slice(0, 32);
-  var IR = I.slice(32);
-
-  var hd = new HDKey(this.versions);
-
-  // Private parent key -> private child key
-  if (this.privateKey) {
-    // ki = parse256(IL) + kpar (mod n)
-    try {
-      hd.privateKey = Buffer.from(
-        secp256k1.privateKeyTweakAdd(Buffer.from(this.privateKey), IL),
+  Object.defineProperty(HDKey.prototype, "publicKey", {
+    get: function () {
+      return this._publicKey;
+    },
+    set: function (value) {
+      assert(
+        value.length === 33 || value.length === 65,
+        "Public key must be 33 or 65 bytes.",
       );
-      // throw if IL >= n || (privateKey + IL) === 0
-    } catch (err) {
-      // In case parse256(IL) >= n or ki == 0, one should proceed with the next value for i
-      return this.deriveChild(index + 1);
-    }
-    // Public parent key -> public child key
-  } else {
-    // Ki = point(parse256(IL)) + Kpar
-    //    = G*IL + Kpar
-    try {
-      hd.publicKey = Buffer.from(
-        secp256k1.publicKeyTweakAdd(Buffer.from(this.publicKey), IL, true),
+      assert(secp256k1.publicKeyVerify(value) === true, "Invalid public key");
+      // force compressed point (performs public key verification)
+      const publicKey =
+        value.length === 65 ? secp256k1.publicKeyConvert(value, true) : value;
+      setPublicKey(this, publicKey);
+    },
+  });
+
+  Object.defineProperty(HDKey.prototype, "privateExtendedKey", {
+    get: function () {
+      if (this._privateKey)
+        return bs58check.encode(
+          serialize(
+            this,
+            this.versions.private,
+            Buffer.concat([Buffer.alloc(1, 0), this.privateKey]),
+          ),
+        );
+      else return null;
+    },
+  });
+
+  Object.defineProperty(HDKey.prototype, "publicExtendedKey", {
+    get: function () {
+      return bs58check.encode(
+        serialize(this, this.versions.public, this.publicKey),
       );
-      // throw if IL >= n || (g**IL + publicKey) is infinity
-    } catch (err) {
-      // In case parse256(IL) >= n or Ki is the point at infinity, one should proceed with the next value for i
-      return this.deriveChild(index + 1);
+    },
+  });
+
+  HDKey.prototype.derive = function (path) {
+    if (path === "m" || path === "M" || path === "m'" || path === "M'") {
+      return this;
     }
-  }
 
-  hd.chainCode = IR;
-  hd.depth = this.depth + 1;
-  hd.parentFingerprint = this.fingerprint; // .readUInt32BE(0)
-  hd.index = index;
+    var entries = path.split("/");
+    var hdkey = this;
+    entries.forEach(function (c, i) {
+      if (i === 0) {
+        assert(/^[mM]{1}/.test(c), 'Path must start with "m" or "M"');
+        return;
+      }
 
-  return hd;
-};
+      var hardened = c.length > 1 && c[c.length - 1] === "'";
+      var childIndex = parseInt(c, 10); // & (HARDENED_OFFSET - 1)
+      assert(childIndex < HARDENED_OFFSET, "Invalid index");
+      if (hardened) childIndex += HARDENED_OFFSET;
 
-HDKey.prototype.sign = function (hash) {
-  return Buffer.from(
-    secp256k1.ecdsaSign(Uint8Array.from(hash), Uint8Array.from(this.privateKey))
-      .signature,
-  );
-};
+      hdkey = hdkey.deriveChild(childIndex);
+    });
 
-HDKey.prototype.verify = function (hash, signature) {
-  return secp256k1.ecdsaVerify(
-    Uint8Array.from(signature),
-    Uint8Array.from(hash),
-    Uint8Array.from(this.publicKey),
-  );
-};
-
-HDKey.prototype.wipePrivateData = function () {
-  if (this._privateKey)
-    crypto.randomBytes(this._privateKey.length).copy(this._privateKey);
-  this._privateKey = null;
-  return this;
-};
-
-HDKey.prototype.toJSON = function () {
-  return {
-    xpriv: this.privateExtendedKey,
-    xpub: this.publicExtendedKey,
+    return hdkey;
   };
-};
 
-HDKey.fromMasterSeed = function (seedBuffer, versions) {
-  var I = crypto
-    .createHmac("sha512", MASTER_SECRET)
-    .update(seedBuffer)
-    .digest();
-  var IL = I.slice(0, 32);
-  var IR = I.slice(32);
+  HDKey.prototype.deriveChild = function (index) {
+    var isHardened = index >= HARDENED_OFFSET;
+    var indexBuffer = Buffer.allocUnsafe(4);
+    indexBuffer.writeUInt32BE(index, 0);
 
-  var hdkey = new HDKey(versions);
-  hdkey.chainCode = IR;
-  hdkey.privateKey = IL;
+    var data;
 
-  return hdkey;
-};
+    if (isHardened) {
+      // Hardened child
+      assert(this.privateKey, "Could not derive hardened child key");
 
-HDKey.fromExtendedKey = function (base58key, versions, skipVerification) {
-  // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
-  versions = versions || BITCOIN_VERSIONS;
-  skipVerification = skipVerification || false;
-  var hdkey = new HDKey(versions);
+      var pk = this.privateKey;
+      var zb = Buffer.alloc(1, 0);
+      pk = Buffer.concat([zb, pk]);
 
-  var keyBuffer = bs58check.decode(base58key);
-
-  var version = keyBuffer.readUInt32BE(0);
-  assert(
-    version === versions.private || version === versions.public,
-    "Version mismatch: does not match private or public",
-  );
-
-  hdkey.depth = keyBuffer.readUInt8(4);
-  hdkey.parentFingerprint = keyBuffer.readUInt32BE(5);
-  hdkey.index = keyBuffer.readUInt32BE(9);
-  hdkey.chainCode = keyBuffer.slice(13, 45);
-
-  var key = keyBuffer.slice(45);
-  if (key.readUInt8(0) === 0) {
-    // private
-    assert(
-      version === versions.private,
-      "Version mismatch: version does not match private",
-    );
-    hdkey.privateKey = key.slice(1); // cut off first 0x0 byte
-  } else {
-    assert(
-      version === versions.public,
-      "Version mismatch: version does not match public",
-    );
-    if (skipVerification) {
-      setPublicKey(hdkey, key);
+      // data = 0x00 || ser256(kpar) || ser32(index)
+      data = Buffer.concat([pk, indexBuffer]);
     } else {
-      hdkey.publicKey = key;
+      // Normal child
+      // data = serP(point(kpar)) || ser32(index)
+      //      = serP(Kpar) || ser32(index)
+      data = Buffer.concat([this.publicKey, indexBuffer]);
     }
+
+    var I = crypto.createHmac("sha512", this.chainCode).update(data).digest();
+    var IL = I.slice(0, 32);
+    var IR = I.slice(32);
+
+    var hd = new HDKey(this.versions);
+
+    // Private parent key -> private child key
+    if (this.privateKey) {
+      // ki = parse256(IL) + kpar (mod n)
+      try {
+        hd.privateKey = Buffer.from(
+          secp256k1.privateKeyTweakAdd(Buffer.from(this.privateKey), IL),
+        );
+        // throw if IL >= n || (privateKey + IL) === 0
+      } catch (err) {
+        // In case parse256(IL) >= n or ki == 0, one should proceed with the next value for i
+        return this.deriveChild(index + 1);
+      }
+      // Public parent key -> public child key
+    } else {
+      // Ki = point(parse256(IL)) + Kpar
+      //    = G*IL + Kpar
+      try {
+        hd.publicKey = Buffer.from(
+          secp256k1.publicKeyTweakAdd(Buffer.from(this.publicKey), IL, true),
+        );
+        // throw if IL >= n || (g**IL + publicKey) is infinity
+      } catch (err) {
+        // In case parse256(IL) >= n or Ki is the point at infinity, one should proceed with the next value for i
+        return this.deriveChild(index + 1);
+      }
+    }
+
+    hd.chainCode = IR;
+    hd.depth = this.depth + 1;
+    hd.parentFingerprint = this.fingerprint; // .readUInt32BE(0)
+    hd.index = index;
+
+    return hd;
+  };
+
+  HDKey.prototype.sign = function (hash) {
+    return Buffer.from(
+      secp256k1.ecdsaSign(
+        Uint8Array.from(hash),
+        Uint8Array.from(this.privateKey),
+      ).signature,
+    );
+  };
+
+  HDKey.prototype.verify = function (hash, signature) {
+    return secp256k1.ecdsaVerify(
+      Uint8Array.from(signature),
+      Uint8Array.from(hash),
+      Uint8Array.from(this.publicKey),
+    );
+  };
+
+  HDKey.prototype.wipePrivateData = function () {
+    if (this._privateKey)
+      crypto.randomBytes(this._privateKey.length).copy(this._privateKey);
+    this._privateKey = null;
+    return this;
+  };
+
+  HDKey.prototype.toJSON = function () {
+    return {
+      xpriv: this.privateExtendedKey,
+      xpub: this.publicExtendedKey,
+    };
+  };
+
+  HDKEY.fromMasterSeed = function (seedBuffer, versions) {
+    var I = crypto
+      .createHmac("sha512", MASTER_SECRET)
+      .update(seedBuffer)
+      .digest();
+    var IL = I.slice(0, 32);
+    var IR = I.slice(32);
+
+    var hdkey = new HDKey(versions);
+    hdkey.chainCode = IR;
+    hdkey.privateKey = IL;
+
+    return hdkey;
+  };
+
+  HDKEY.fromExtendedKey = function (base58key, versions, skipVerification) {
+    // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
+    versions = versions || BITCOIN_VERSIONS;
+    skipVerification = skipVerification || false;
+    var hdkey = new HDKey(versions);
+
+    var keyBuffer = bs58check.decode(base58key);
+
+    var version = keyBuffer.readUInt32BE(0);
+    assert(
+      version === versions.private || version === versions.public,
+      "Version mismatch: does not match private or public",
+    );
+
+    hdkey.depth = keyBuffer.readUInt8(4);
+    hdkey.parentFingerprint = keyBuffer.readUInt32BE(5);
+    hdkey.index = keyBuffer.readUInt32BE(9);
+    hdkey.chainCode = keyBuffer.slice(13, 45);
+
+    var key = keyBuffer.slice(45);
+    if (key.readUInt8(0) === 0) {
+      // private
+      assert(
+        version === versions.private,
+        "Version mismatch: version does not match private",
+      );
+      hdkey.privateKey = key.slice(1); // cut off first 0x0 byte
+    } else {
+      assert(
+        version === versions.public,
+        "Version mismatch: version does not match public",
+      );
+      if (skipVerification) {
+        setPublicKey(hdkey, key);
+      } else {
+        hdkey.publicKey = key;
+      }
+    }
+
+    return hdkey;
+  };
+
+  HDKEY.fromJSON = function (obj) {
+    return HDKEY.fromExtendedKey(obj.xpriv);
+  };
+
+  function serialize(hdkey, version, key) {
+    // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
+    var buffer = Buffer.allocUnsafe(LEN);
+
+    buffer.writeUInt32BE(version, 0);
+    buffer.writeUInt8(hdkey.depth, 4);
+
+    var fingerprint = hdkey.depth ? hdkey.parentFingerprint : 0x00000000;
+    buffer.writeUInt32BE(fingerprint, 5);
+    buffer.writeUInt32BE(hdkey.index, 9);
+
+    hdkey.chainCode.copy(buffer, 13);
+    key.copy(buffer, 45);
+
+    return buffer;
   }
 
-  return hdkey;
-};
+  function setPublicKey(hdkey, publicKey) {
+    hdkey._publicKey = Buffer.from(publicKey);
+    hdkey._identifier = hash160(publicKey);
+    hdkey._fingerprint = hdkey._identifier.slice(0, 4).readUInt32BE(0);
+    hdkey._privateKey = null;
+  }
 
-HDKey.fromJSON = function (obj) {
-  return HDKey.fromExtendedKey(obj.xpriv);
-};
+  function hash160(buf) {
+    var sha = crypto.createHash("sha256").update(buf).digest();
+    return new RIPEMD160().update(sha).digest();
+  }
 
-function serialize(hdkey, version, key) {
-  // => version(4) || depth(1) || fingerprint(4) || index(4) || chain(32) || key(33)
-  var buffer = Buffer.allocUnsafe(LEN);
-
-  buffer.writeUInt32BE(version, 0);
-  buffer.writeUInt8(hdkey.depth, 4);
-
-  var fingerprint = hdkey.depth ? hdkey.parentFingerprint : 0x00000000;
-  buffer.writeUInt32BE(fingerprint, 5);
-  buffer.writeUInt32BE(hdkey.index, 9);
-
-  hdkey.chainCode.copy(buffer, 13);
-  key.copy(buffer, 45);
-
-  return buffer;
+  HDKEY.HARDENED_OFFSET = HARDENED_OFFSET;
+})(globalThis.window || {}, HDKEY);
+if ("object" === typeof module) {
+  module.exports = HDKEY;
 }
-
-function hash160(buf) {
-  var sha = crypto.createHash("sha256").update(buf).digest();
-  return new RIPEMD160().update(sha).digest();
-}
-
-HDKey.HARDENED_OFFSET = HARDENED_OFFSET;
-module.exports = HDKey;

--- a/test/hdkey.test.js
+++ b/test/hdkey.test.js
@@ -17,8 +17,8 @@ describe("hdkey", function () {
         var hdkey = HDKey.fromMasterSeed(Buffer.from(f.seed, "hex"));
         var childkey = hdkey.derive(f.path);
 
-        assert.equal(childkey.privateExtendedKey, f.private);
-        assert.equal(childkey.publicExtendedKey, f.public);
+        assert.equal(childkey.getPrivateExtendedKey(), f.private);
+        assert.equal(childkey.getPublicExtendedKey(), f.public);
       });
 
       describe("> " + f.path + " toJSON() / fromJSON()", function () {
@@ -34,8 +34,8 @@ describe("hdkey", function () {
           assert.deepEqual(childkey.toJSON(), obj);
 
           var newKey = HDKey.fromJSON(obj);
-          assert.strictEqual(newKey.privateExtendedKey, f.private);
-          assert.strictEqual(newKey.publicExtendedKey, f.public);
+          assert.strictEqual(newKey.getPrivateExtendedKey(), f.private);
+          assert.strictEqual(newKey.getPublicExtendedKey(), f.public);
         });
       });
     });
@@ -43,9 +43,9 @@ describe("hdkey", function () {
 
   describe("- privateKey", function () {
     it("should throw an error if incorrect key size", function () {
-      var hdkey = new HDKey();
+      var hdkey = HDKey.create();
       assert.throws(function () {
-        hdkey.privateKey = Buffer.from([1, 2, 3, 4]);
+        hdkey.setPrivateKey(Buffer.from([1, 2, 3, 4]));
       }, /key must be 32/);
     });
   });
@@ -53,8 +53,8 @@ describe("hdkey", function () {
   describe("- publicKey", function () {
     it("should throw an error if incorrect key size", function () {
       assert.throws(function () {
-        var hdkey = new HDKey();
-        hdkey.publicKey = Buffer.from([1, 2, 3, 4]);
+        var hdkey = HDKey.create();
+        hdkey.setPublicKey(Buffer.from([1, 2, 3, 4]));
       }, /key must be 33 or 65/);
     });
 
@@ -62,16 +62,16 @@ describe("hdkey", function () {
       var priv = secureRandom.randomBuffer(32);
       var pub = curve.G.multiply(BigInteger.fromBuffer(priv)).getEncoded(true);
       assert.equal(pub.length, 33);
-      var hdkey = new HDKey();
-      hdkey.publicKey = pub;
+      var hdkey = HDKey.create();
+      hdkey.setPublicKey(pub);
     });
 
     it("should not throw if key is 65 bytes (not compressed)", function () {
       var priv = secureRandom.randomBuffer(32);
       var pub = curve.G.multiply(BigInteger.fromBuffer(priv)).getEncoded(false);
       assert.equal(pub.length, 65);
-      var hdkey = new HDKey();
-      hdkey.publicKey = pub;
+      var hdkey = HDKey.create();
+      hdkey.setPublicKey(pub);
     });
   });
 
@@ -92,7 +92,7 @@ describe("hdkey", function () {
           "9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271",
         );
         assert.equal(
-          hdkey.privateKey.toString("hex"),
+          hdkey.getPrivateKey().toString("hex"),
           "bb7d39bdb83ecf58f2fd82b6d918341cbef428661ef01ab97c28a4842125ac23",
         );
         assert.equal(
@@ -121,7 +121,7 @@ describe("hdkey", function () {
           hdkey.chainCode.toString("hex"),
           "9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271",
         );
-        assert.equal(hdkey.privateKey, null);
+        assert.equal(hdkey.getPrivateKey(), null);
         assert.equal(
           hdkey.publicKey.toString("hex"),
           "024d902e1a2fc7a8755ab5b694c575fce742c48d9ff192e63df5193e4c7afe1f9c",
@@ -146,7 +146,7 @@ describe("hdkey", function () {
           hdkey.chainCode.toString("hex"),
           "9452b549be8cea3ecb7a84bec10dcfd94afe4d129ebfd3b3cb58eedf394ed271",
         );
-        assert.equal(hdkey.privateKey, null);
+        assert.equal(hdkey.getPrivateKey(), null);
         assert.equal(
           hdkey.publicKey.toString("hex"),
           "024d902e1a2fc7a8755ab5b694c575fce742c48d9ff192e63df5193e4c7afe1f9c",
@@ -203,7 +203,7 @@ describe("hdkey", function () {
 
       var expected =
         "xpub6JdKdVJtdx6sC3nh87pDvnGhotXuU5Kz6Qy7Piy84vUAwWSYShsUGULE8u6gCivTHgz7cCKJHiXaaMeieB4YnoFVAsNgHHKXJ2mN6jCMbH1";
-      assert.equal(derivedHDKey.publicExtendedKey, expected);
+      assert.equal(derivedHDKey.getPublicExtendedKey(), expected);
     });
   });
 
@@ -215,7 +215,7 @@ describe("hdkey", function () {
       var newKey = masterKey.derive("m/44'/6'/4'");
       var expected =
         "xprv9ymoag6W7cR6KBcJzhCM6qqTrb3rRVVwXKzwNqp1tDWcwierEv3BA9if3ARHMhMPh9u2jNoutcgpUBLMfq3kADDo7LzfoCnhhXMRGX3PXDx";
-      assert.equal(newKey.privateExtendedKey, expected);
+      assert.equal(newKey.getPrivateExtendedKey(), expected);
     });
   });
 
@@ -231,12 +231,12 @@ describe("hdkey", function () {
         "xprv9s21ZrQH143K3ckY9DgU79uMTJkQRLdbCCVDh81SnxTgPzLLGax6uHeBULTtaEtcAvKjXfT7ZWtHzKjTpujMkUd9dDb8msDeAfnJxrgAYhr";
       var hdkey = HDKey.fromExtendedKey(key);
       assert.equal(
-        hdkey.privateKey.toString("hex"),
+        hdkey.getPrivateKey().toString("hex"),
         "00000055378cf5fafb56c711c674143f9b0ee82ab0ba2924f19b64f5ae7cdbfd",
       );
       var derived = hdkey.derive("m/44'/0'/0'/0/0'");
       assert.equal(
-        derived.privateKey.toString("hex"),
+        derived.getPrivateKey().toString("hex"),
         "3348069561d2a0fb925e74bf198762acc47dce7db27372257d2d959a9e6f8aeb",
       );
     });
@@ -247,14 +247,14 @@ describe("hdkey", function () {
       var seed = "000102030405060708090a0b0c0d0e0f";
       var masterKey = HDKey.fromMasterSeed(Buffer.from(seed, "hex"));
 
-      assert.ok(masterKey.privateExtendedKey, "xpriv is truthy");
-      masterKey._privateKey = null;
+      assert.ok(masterKey.getPrivateExtendedKey(), "xpriv is truthy");
+      masterKey.wipePrivateData();
 
       assert.doesNotThrow(function () {
-        masterKey.privateExtendedKey;
+        masterKey.getPrivateExtendedKey();
       });
 
-      assert.ok(!masterKey.privateExtendedKey, "xpriv is falsy");
+      assert.ok(!masterKey.getPrivateExtendedKey(), "xpriv is falsy");
     });
   });
 
@@ -274,7 +274,8 @@ describe("hdkey", function () {
   describe(" - when the path given to derive does not begin with master extended key", function () {
     it("should throw an error", function () {
       assert.throws(function () {
-        HDKey.prototype.derive("123");
+        const hdkey = HDKey.create();
+        hdkey.derive("123");
       }, /Path must start with "m" or "M"/);
     });
   });
@@ -284,16 +285,16 @@ describe("hdkey", function () {
       const hdkey = HDKey.fromMasterSeed(
         Buffer.from(fixtures.valid[6].seed, "hex"),
       ).wipePrivateData();
-      assert.equal(hdkey.privateKey, null);
-      assert.equal(hdkey.privateExtendedKey, null);
+      assert.equal(hdkey.getPrivateKey(), null);
+      assert.equal(hdkey.getPrivateExtendedKey(), null);
       assert.throws(
         () => hdkey.sign(Buffer.alloc(32)),
         "shouldn't be able to sign",
       );
       const childKey = hdkey.derive("m/0");
-      assert.equal(childKey.publicExtendedKey, fixtures.valid[7].public);
-      assert.equal(childKey.privateKey, null);
-      assert.equal(childKey.privateExtendedKey, null);
+      assert.equal(childKey.getPublicExtendedKey(), fixtures.valid[7].public);
+      assert.equal(childKey.getPrivateKey(), null);
+      assert.equal(childKey.getPrivateExtendedKey(), null);
     });
 
     it("should have correct data", function () {
@@ -332,7 +333,7 @@ describe("hdkey", function () {
     it("should not throw if called on hdkey without private data", function () {
       const hdkey = HDKey.fromExtendedKey(fixtures.valid[0].public);
       assert.doesNotThrow(() => hdkey.wipePrivateData());
-      assert.equal(hdkey.publicExtendedKey, fixtures.valid[0].public);
+      assert.equal(hdkey.getPublicExtendedKey(), fixtures.valid[0].public);
     });
   });
 
@@ -340,24 +341,24 @@ describe("hdkey", function () {
     it("should not mutate it when deriving with a private key", function () {
       const hdkey = HDKey.fromExtendedKey(fixtures.valid[0].private);
       const path = "m/123";
-      const privateKeyBefore = hdkey.privateKey.toString("hex");
+      const privateKeyBefore = hdkey.getPrivateKey().toString("hex");
 
       const child = hdkey.derive(path);
-      assert.equal(hdkey.privateKey.toString("hex"), privateKeyBefore);
+      assert.equal(hdkey.getPrivateKey().toString("hex"), privateKeyBefore);
 
       const child2 = hdkey.derive(path);
-      assert.equal(hdkey.privateKey.toString("hex"), privateKeyBefore);
+      assert.equal(hdkey.getPrivateKey().toString("hex"), privateKeyBefore);
 
       const child3 = hdkey.derive(path);
-      assert.equal(hdkey.privateKey.toString("hex"), privateKeyBefore);
+      assert.equal(hdkey.getPrivateKey().toString("hex"), privateKeyBefore);
 
       assert.equal(
-        child.privateKey.toString("hex"),
-        child2.privateKey.toString("hex"),
+        child.getPrivateKey().toString("hex"),
+        child2.getPrivateKey().toString("hex"),
       );
       assert.equal(
-        child2.privateKey.toString("hex"),
-        child3.privateKey.toString("hex"),
+        child2.getPrivateKey().toString("hex"),
+        child3.getPrivateKey().toString("hex"),
       );
     });
 


### PR DESCRIPTION
- [x] painstakingly refactored for incremental improvement and testing via #4 
- [x] added (future-looking) type defs
- [x] swap `assert` for a simple function
- [x] swap `crypto` for `WebCrypto`
- [x] swap `Buffer` for `Uint8Array` and `DataView`
- [x] swap `secp256k1` for noble `@dashincubator/secp256k1`
- [x] swap `bs58check` and `ripemd160` for `dashkeys`