### PR TITLE
doc: use practical variable names rather than mathematical notation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashhd",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashhd",
-      "version": "3.0.6",
+      "version": "3.1.0",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "dashkeys": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashhd",
-  "version": "3.0.6",
+  "version": "3.1.0",
   "description": "Manage HD Keys from HD Wallet Seed and Extended (xprv, xpub) Key Paths. Part of $DASH Tools.",
   "main": "dashhd.js",
   "browser": {


### PR DESCRIPTION
A lot of the FUD around the security (or lack thereof) is due to the use of abstract mathematical-esque notation (ex `seed`, `I`, `IL`, `IR`) rather than the clear indication of what pieces of information are being used.

Also, the associative-ness of the key transformations can be made much more clear by always applying it to the public key.