### PR TITLE
fix: pass 'version' properly, for 'tprv' and 'testnet'

### DIFF
--- a/dashhd.js
+++ b/dashhd.js
@@ -813,7 +813,7 @@ if ("object" === typeof module) {
 /**
  * @callback HDFingerprint
  * @param {Uint8Array} pubBytes - Public Key
- * @returns {Number}
+ * @returns {Promise<Number>}
  */
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,19 +9,19 @@
       "version": "3.3.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "dashkeys": "^1.0.0"
+        "dashkeys": "^1.1.1"
       },
       "devDependencies": {
-        "@dashincubator/secp256k1": "^1.7.1-4",
-        "dashphrase": "^1.3.1",
+        "@dashincubator/secp256k1": "^1.7.1-5",
+        "dashphrase": "^1.4.0",
         "mocha": "^10.2.0",
         "mocha-lcov-reporter": "0.0.1"
       }
     },
     "node_modules/@dashincubator/secp256k1": {
-      "version": "1.7.1-4",
-      "resolved": "https://registry.npmjs.org/@dashincubator/secp256k1/-/secp256k1-1.7.1-4.tgz",
-      "integrity": "sha512-dQ6ZOZQL0nWGc1bs6baD/qD4LJsiNlT4E7kXgTkK86o0po1rN/H0lVcikeBMfLJIaVUVYjH6sygScEGOy+17wA==",
+      "version": "1.7.1-5",
+      "resolved": "https://registry.npmjs.org/@dashincubator/secp256k1/-/secp256k1-1.7.1-5.tgz",
+      "integrity": "sha512-3iA+RDZrJsRFPpWhlYkp3EdoFAlKjdqkNFiRwajMrzcpA/G/IBX0AnC1pwRLkTrM+tUowcyGrkJfT03U4ETZeg==",
       "dev": true
     },
     "node_modules/ansi-colors": {
@@ -221,14 +221,14 @@
       "dev": true
     },
     "node_modules/dashkeys": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/dashkeys/-/dashkeys-1.0.0.tgz",
-      "integrity": "sha512-Ph3wlQEJUEYTSqBMVxIR/MuO9L2aIccvglTsB7Kws1ARPt1wW4iyNUT8axY954+ZqSNqVQKj7TSxxLe/IA/Q5w=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/dashkeys/-/dashkeys-1.1.1.tgz",
+      "integrity": "sha512-UXM/Dszqli8MmbZIqOWvGZLPF6g5bpuvxNeyK8HmYAreWGyyQyanq7EDpw0NP8oFW3/K0c0xuE2CkWYpdf/rbQ=="
     },
     "node_modules/dashphrase": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/dashphrase/-/dashphrase-1.3.1.tgz",
-      "integrity": "sha512-Qs6jYCeEyaj1W+tXU+4OqvvaFMJs9ej1bhacvJ8dq6YlUmVWds/5UUD3mxp/VElkF/KbtkjVWinyYtY0V/yb9g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/dashphrase/-/dashphrase-1.4.0.tgz",
+      "integrity": "sha512-o+LdiPkiYmg07kXBE+2bbcJzBmeTQVPn1GS2XlQeo8lene+KknAprSyiYi5XtqV/QVgNjvzOV7qBst2MijSPAA==",
       "dev": true
     },
     "node_modules/debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashhd",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashhd",
-      "version": "3.3.0",
+      "version": "3.3.1",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "dashkeys": "^1.0.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dashhd",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dashhd",
-      "version": "3.3.1",
+      "version": "3.3.2",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "dashkeys": "^1.1.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashhd",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "description": "Manage HD Keys from HD Wallet Seed and Extended (xprv, xpub) Key Paths. Part of $DASH Tools.",
   "main": "dashhd.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dashhd",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Manage HD Keys from HD Wallet Seed and Extended (xprv, xpub) Key Paths. Part of $DASH Tools.",
   "main": "dashhd.js",
   "browser": {

--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
     "jsconfig.json"
   ],
   "devDependencies": {
-    "@dashincubator/secp256k1": "^1.7.1-4",
-    "dashphrase": "^1.3.1",
+    "@dashincubator/secp256k1": "^1.7.1-5",
+    "dashphrase": "^1.4.0",
     "mocha": "^10.2.0",
     "mocha-lcov-reporter": "0.0.1"
   },
   "dependencies": {
-    "dashkeys": "^1.0.0"
+    "dashkeys": "^1.1.1"
   },
   "scripts": {
     "lint": "npx -p typescript@4.x -- tsc -p ./jsconfig.json",


### PR DESCRIPTION
- 'xprv' and 'tprv' are accepted as strings
- other xkey versions are accepted as Uint32
- `toWif`, `toXPrv`, and `toXPub` now correctly pass `opts` (with `version`) to DashKeys
- remove duplicate `opts.xkey` from `fromXKey()` definition
- unexport types for `DashHd.utils`, which is currently private as `Dashhd._utils`
- `fromXKey()` accepts colloquial "mainnet", "testnet", "xpub", etc